### PR TITLE
Fix mgmt query

### DIFF
--- a/kusto/internal/frames/frames.go
+++ b/kusto/internal/frames/frames.go
@@ -56,6 +56,7 @@ const (
 	QueryCompletionInformation TableKind = "QueryCompletionInformation"
 	QueryTraceLog              TableKind = "QueryTraceLog"
 	QueryPerfLog               TableKind = "QueryPerfLog"
+	QueryResult                TableKind = "QueryResult"
 	TableOfContents            TableKind = "TableOfContents"
 	QueryPlan                  TableKind = "QueryPlan"
 	ExtendedProperties         TableKind = "@ExtendedProperties"

--- a/kusto/statemachine_test.go
+++ b/kusto/statemachine_test.go
@@ -776,6 +776,13 @@ func TestV1SM(t *testing.T) {
 					},
 					KustoRows: []value.Values{
 						{
+							value.Long{Value: 0, Valid: true},
+							value.String{Value: "QueryResult", Valid: true},
+							value.String{Value: "PrimaryResult", Valid: true},
+							value.String{Value: "07dd9603-3e06-4c62-986b-dfc3d586b05a", Valid: true},
+							value.String{Value: "", Valid: true},
+						},
+						{
 							value.Long{Value: 1, Valid: true},
 							value.String{Value: "QueryProperties", Valid: true},
 							value.String{Value: "@ExtendedProperties", Valid: true},
@@ -784,13 +791,6 @@ func TestV1SM(t *testing.T) {
 						},
 						{
 							value.Long{Value: 2, Valid: true},
-							value.String{Value: "QueryResult", Valid: true},
-							value.String{Value: "PrimaryResult", Valid: true},
-							value.String{Value: "07dd9603-3e06-4c62-986b-dfc3d586b05a", Valid: true},
-							value.String{Value: "", Valid: true},
-						},
-						{
-							value.Long{Value: 0, Valid: true},
 							value.String{Value: "QueryResult", Valid: true},
 							value.String{Value: "PrimaryResult", Valid: true},
 							value.String{Value: "07dd9603-3e06-4c62-986b-dfc3d586b05a", Valid: true},
@@ -808,8 +808,8 @@ func TestV1SM(t *testing.T) {
 					},
 					Values: value.Values{
 						value.DateTime{Value: nowish, Valid: true},
-						value.String{Value: "DD", Valid: true},
-						value.Long{Value: 101, Valid: true},
+						value.String{Value: "Doak", Valid: true},
+						value.Long{Value: 10, Valid: true},
 					},
 					Op: errors.OpQuery,
 				},
@@ -821,8 +821,8 @@ func TestV1SM(t *testing.T) {
 					},
 					Values: value.Values{
 						value.DateTime{Value: nowish, Valid: true},
-						value.String{Value: "Doak", Valid: true},
-						value.Long{Value: 10, Valid: true},
+						value.String{Value: "DD", Valid: true},
+						value.Long{Value: 101, Valid: true},
 					},
 					Op: errors.OpQuery,
 				},

--- a/kusto/statemachine_test.go
+++ b/kusto/statemachine_test.go
@@ -575,7 +575,7 @@ func TestV1SM(t *testing.T) {
 			err:    true,
 		},
 		{
-			desc: "Expected Result",
+			desc: "Single Table",
 			ctx:  context.Background(),
 			stream: []frames.Frame{
 				v1.DataTable{
@@ -589,20 +589,6 @@ func TestV1SM(t *testing.T) {
 							value.DateTime{Value: nowish, Valid: true},
 							value.String{Value: "Doak", Valid: true},
 							value.Long{Value: 10, Valid: true},
-						},
-					},
-				},
-				v1.DataTable{
-					DataTypes: v1.DataTypes{
-						{ColumnName: "Timestamp", ColumnType: "datetime"},
-						{ColumnName: "Name", ColumnType: "string"},
-						{ColumnName: "ID", ColumnType: "long"},
-					},
-					KustoRows: []value.Values{
-						{
-							value.DateTime{Value: nowish, Valid: true},
-							value.String{Value: "Dubovski", Valid: true},
-							value.Long{Value: 0, Valid: false},
 						},
 					},
 				},
@@ -621,6 +607,38 @@ func TestV1SM(t *testing.T) {
 					},
 					Op: errors.OpQuery,
 				},
+			},
+		},
+		{
+			desc: "Primary And QueryProperties",
+			ctx:  context.Background(),
+			stream: []frames.Frame{
+				v1.DataTable{
+					DataTypes: v1.DataTypes{
+						{ColumnName: "Timestamp", ColumnType: "datetime"},
+						{ColumnName: "Name", ColumnType: "string"},
+						{ColumnName: "ID", ColumnType: "long"},
+					},
+					KustoRows: []value.Values{
+						{
+							value.DateTime{Value: nowish, Valid: true},
+							value.String{Value: "Doak", Valid: true},
+							value.Long{Value: 10, Valid: true},
+						},
+					},
+				},
+				v1.DataTable{
+					DataTypes: v1.DataTypes{
+						{ColumnName: "Value", ColumnType: "string"},
+					},
+					KustoRows: []value.Values{
+						{
+							value.String{Value: "{\"Visualization\":null,\"Title\":null,\"XColumn\":null,\"Series\":null,\"YColumns\":null,\"AnomalyColumns\":null,\"XTitle\":null,\"YTitle\":null,\"XAxis\":null,\"YAxis\":null,\"Legend\":null,\"YSplit\":null,\"Accumulate\":false,\"IsQuerySorted\":false,\"Kind\":null,\"Ymin\":\"NaN\",\"Ymax\":\"NaN\"}", Valid: true},
+						},
+					},
+				},
+			},
+			want: table.Rows{
 				&table.Row{
 					ColumnTypes: table.Columns{
 						{Name: "Timestamp", Type: "datetime"},
@@ -629,8 +647,182 @@ func TestV1SM(t *testing.T) {
 					},
 					Values: value.Values{
 						value.DateTime{Value: nowish, Valid: true},
-						value.String{Value: "Dubovski", Valid: true},
-						value.Long{Value: 0, Valid: false},
+						value.String{Value: "Doak", Valid: true},
+						value.Long{Value: 10, Valid: true},
+					},
+					Op: errors.OpQuery,
+				},
+			},
+		},
+		{
+			desc: "Primary With TableOfContents",
+			ctx:  context.Background(),
+			stream: []frames.Frame{
+				v1.DataTable{
+					DataTypes: v1.DataTypes{
+						{ColumnName: "Timestamp", ColumnType: "datetime"},
+						{ColumnName: "Name", ColumnType: "string"},
+						{ColumnName: "ID", ColumnType: "long"},
+					},
+					KustoRows: []value.Values{
+						{
+							value.DateTime{Value: nowish, Valid: true},
+							value.String{Value: "Doak", Valid: true},
+							value.Long{Value: 10, Valid: true},
+						},
+					},
+				},
+				v1.DataTable{
+					DataTypes: v1.DataTypes{
+						{ColumnName: "Value", ColumnType: "string"},
+					},
+					KustoRows: []value.Values{
+						{
+							value.String{Value: "{\"Visualization\":null,\"Title\":null,\"XColumn\":null,\"Series\":null,\"YColumns\":null,\"AnomalyColumns\":null,\"XTitle\":null,\"YTitle\":null,\"XAxis\":null,\"YAxis\":null,\"Legend\":null,\"YSplit\":null,\"Accumulate\":false,\"IsQuerySorted\":false,\"Kind\":null,\"Ymin\":\"NaN\",\"Ymax\":\"NaN\"}", Valid: true},
+						},
+					},
+				},
+				v1.DataTable{
+					DataTypes: v1.DataTypes{
+						{ColumnName: "Ordinal", ColumnType: "long"},
+						{ColumnName: "Kind", ColumnType: "string"},
+						{ColumnName: "Name", ColumnType: "string"},
+						{ColumnName: "Id", ColumnType: "string"},
+						{ColumnName: "PrettyName", ColumnType: "string"},
+					},
+					KustoRows: []value.Values{
+						{
+							value.Long{Value: 0, Valid: true},
+							value.String{Value: "QueryResult", Valid: true},
+							value.String{Value: "PrimaryResult", Valid: true},
+							value.String{Value: "07dd9603-3e06-4c62-986b-dfc3d586b05a", Valid: true},
+							value.String{Value: "", Valid: true},
+						},
+						{
+							value.Long{Value: 1, Valid: true},
+							value.String{Value: "QueryProperties", Valid: true},
+							value.String{Value: "@ExtendedProperties", Valid: true},
+							value.String{Value: "309c015e-5693-4b66-92e7-4a4f98c3155b", Valid: true},
+							value.String{Value: "", Valid: true},
+						},
+					},
+				},
+			},
+			want: table.Rows{
+				&table.Row{
+					ColumnTypes: table.Columns{
+						{Name: "Timestamp", Type: "datetime"},
+						{Name: "Name", Type: "string"},
+						{Name: "ID", Type: "long"},
+					},
+					Values: value.Values{
+						value.DateTime{Value: nowish, Valid: true},
+						value.String{Value: "Doak", Valid: true},
+						value.Long{Value: 10, Valid: true},
+					},
+					Op: errors.OpQuery,
+				},
+			},
+		},
+		{
+			desc: "Multiple Primaries",
+			ctx:  context.Background(),
+			stream: []frames.Frame{
+				v1.DataTable{
+					DataTypes: v1.DataTypes{
+						{ColumnName: "Timestamp", ColumnType: "datetime"},
+						{ColumnName: "Name", ColumnType: "string"},
+						{ColumnName: "ID", ColumnType: "long"},
+					},
+					KustoRows: []value.Values{
+						{
+							value.DateTime{Value: nowish, Valid: true},
+							value.String{Value: "Doak", Valid: true},
+							value.Long{Value: 10, Valid: true},
+						},
+					},
+				},
+				v1.DataTable{
+					DataTypes: v1.DataTypes{
+						{ColumnName: "Value", ColumnType: "string"},
+					},
+					KustoRows: []value.Values{
+						{
+							value.String{Value: "{\"Visualization\":null,\"Title\":null,\"XColumn\":null,\"Series\":null,\"YColumns\":null,\"AnomalyColumns\":null,\"XTitle\":null,\"YTitle\":null,\"XAxis\":null,\"YAxis\":null,\"Legend\":null,\"YSplit\":null,\"Accumulate\":false,\"IsQuerySorted\":false,\"Kind\":null,\"Ymin\":\"NaN\",\"Ymax\":\"NaN\"}", Valid: true},
+						},
+					},
+				},
+				v1.DataTable{
+					DataTypes: v1.DataTypes{
+						{ColumnName: "Timestamp", ColumnType: "datetime"},
+						{ColumnName: "Name", ColumnType: "string"},
+						{ColumnName: "ID", ColumnType: "long"},
+					},
+					KustoRows: []value.Values{
+						{
+							value.DateTime{Value: nowish, Valid: true},
+							value.String{Value: "DD", Valid: true},
+							value.Long{Value: 101, Valid: true},
+						},
+					},
+				},
+				v1.DataTable{
+					DataTypes: v1.DataTypes{
+						{ColumnName: "Ordinal", ColumnType: "long"},
+						{ColumnName: "Kind", ColumnType: "string"},
+						{ColumnName: "Name", ColumnType: "string"},
+						{ColumnName: "Id", ColumnType: "string"},
+						{ColumnName: "PrettyName", ColumnType: "string"},
+					},
+					KustoRows: []value.Values{
+						{
+							value.Long{Value: 1, Valid: true},
+							value.String{Value: "QueryProperties", Valid: true},
+							value.String{Value: "@ExtendedProperties", Valid: true},
+							value.String{Value: "309c015e-5693-4b66-92e7-4a4f98c3155b", Valid: true},
+							value.String{Value: "", Valid: true},
+						},
+						{
+							value.Long{Value: 2, Valid: true},
+							value.String{Value: "QueryResult", Valid: true},
+							value.String{Value: "PrimaryResult", Valid: true},
+							value.String{Value: "07dd9603-3e06-4c62-986b-dfc3d586b05a", Valid: true},
+							value.String{Value: "", Valid: true},
+						},
+						{
+							value.Long{Value: 0, Valid: true},
+							value.String{Value: "QueryResult", Valid: true},
+							value.String{Value: "PrimaryResult", Valid: true},
+							value.String{Value: "07dd9603-3e06-4c62-986b-dfc3d586b05a", Valid: true},
+							value.String{Value: "", Valid: true},
+						},
+					},
+				},
+			},
+			want: table.Rows{
+				&table.Row{
+					ColumnTypes: table.Columns{
+						{Name: "Timestamp", Type: "datetime"},
+						{Name: "Name", Type: "string"},
+						{Name: "ID", Type: "long"},
+					},
+					Values: value.Values{
+						value.DateTime{Value: nowish, Valid: true},
+						value.String{Value: "DD", Valid: true},
+						value.Long{Value: 101, Valid: true},
+					},
+					Op: errors.OpQuery,
+				},
+				&table.Row{
+					ColumnTypes: table.Columns{
+						{Name: "Timestamp", Type: "datetime"},
+						{Name: "Name", Type: "string"},
+						{Name: "ID", Type: "long"},
+					},
+					Values: value.Values{
+						value.DateTime{Value: nowish, Valid: true},
+						value.String{Value: "Doak", Valid: true},
+						value.Long{Value: 10, Valid: true},
 					},
 					Op: errors.OpQuery,
 				},


### PR DESCRIPTION
Fixes #55 

This PR matches the logic of V1 queries parsing to the standard.
For example here's the java implementation - 
https://github.com/Azure/azure-kusto-java/blob/03aabae864c68bca07519c541a02ffaef4f85c00/data/src/main/java/com/microsoft/azure/kusto/data/KustoOperationResult.java#L58

Basically the logic is -
1. If there's 1 or 2 tables, the primary table is the first one
2. If there's more, the last table will be a table of contents that tells which tables are the primary ones

This breaks the stream-like approach we usually takes, because we have to check all of the tables before we know what to send to the user.

This implementation does that, but to do so I had to break from the "state machine" model a bit.

The method `tableOfContents` calls directly to `dataTable`, which feels wrong since you are supposed to return the method and have the state machine loop call it.
But I'm not sure what would be a better alternative - 
maybe sending the ordinals of the primary tables through a channel, and then reading form that channel in the state machine,
but this seems very inefficient. 