### PR TITLE
Stop caching manager as it no longer fits the design

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,6 +45,8 @@ jobs:
           APP_KEY: ${{ secrets.APP_KEY }}
           AUTH_ID: ${{ secrets.AUTH_ID }}
           TEST_DATABASE: ${{ secrets.TEST_DATABASE }}
+          SECONDARY_ENGINE_CONNECTION_STRING: ${{ secrets.SECONDARY_ENGINE_CONNECTION_STRING }}
+          SECONDARY_DATABASE: ${{ secrets.SECONDARY_DATABASE }}
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()

--- a/kusto/ingest/ingest.go
+++ b/kusto/ingest/ingest.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Azure/azure-kusto-go/kusto"
 	"github.com/Azure/azure-kusto-go/kusto/data/errors"
 	"github.com/Azure/azure-kusto-go/kusto/ingest/internal/conn"
 	"github.com/Azure/azure-kusto-go/kusto/ingest/internal/filesystem"
@@ -24,7 +23,7 @@ type Ingestion struct {
 	db    string
 	table string
 
-	client *kusto.Client
+	client QueryClient
 	mgr    *resources.Manager
 
 	fs *filesystem.Ingestion
@@ -48,7 +47,7 @@ func WithStaticBuffer(bufferSize int, maxBuffers int) Option {
 }
 
 // New is a constructor for Ingestion.
-func New(client *kusto.Client, db, table string, options ...Option) (*Ingestion, error) {
+func New(client QueryClient, db, table string, options ...Option) (*Ingestion, error) {
 	mgr, err := resources.New(client)
 	if err != nil {
 		return nil, err

--- a/kusto/ingest/ingest_test.go
+++ b/kusto/ingest/ingest_test.go
@@ -1,0 +1,143 @@
+package ingest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-kusto-go/kusto"
+	"github.com/Azure/azure-kusto-go/kusto/data/table"
+	"github.com/Azure/azure-kusto-go/kusto/data/types"
+	"github.com/Azure/azure-kusto-go/kusto/ingest/internal/resources"
+)
+
+type mockClient struct {
+	endpoint string
+	auth     kusto.Authorization
+}
+
+func (m mockClient) Auth() kusto.Authorization {
+	return m.auth
+}
+
+func (m mockClient) Endpoint() string {
+	return m.endpoint
+}
+
+func (m mockClient) Query(context.Context, string, kusto.Stmt, ...kusto.QueryOption) (*kusto.RowIterator, error) {
+	panic("not implemented")
+}
+
+func (m mockClient) Mgmt(context.Context, string, kusto.Stmt, ...kusto.MgmtOption) (*kusto.RowIterator, error) {
+	rows, err := kusto.NewMockRows(table.Columns{
+		{
+			Name: "ResourceTypeName",
+			Type: types.String,
+		},
+		{
+			Name: "StorageRoot",
+			Type: types.String,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	iter := &kusto.RowIterator{}
+	err = iter.Mock(rows)
+	if err != nil {
+		return nil, err
+	}
+
+	return iter, nil
+}
+
+func TestManager(t *testing.T) {
+
+	firstMockClient := mockClient{
+		endpoint: "https://test.kusto.windows.net",
+		auth:     kusto.Authorization{},
+	}
+	mockClientSame := mockClient{
+		endpoint: "https://test.kusto.windows.net",
+		auth:     kusto.Authorization{},
+	}
+	secondMockClient := mockClient{
+		endpoint: "https://test2.kusto.windows.net",
+		auth:     kusto.Authorization{},
+	}
+
+	tests := []struct {
+		name    string
+		clients []func() *Ingestion
+	}{
+		{
+			name: "TestSameClient",
+			clients: []func() *Ingestion{
+				func() *Ingestion {
+					ingestion, _ := New(firstMockClient, "test", "test")
+					return ingestion
+				},
+				func() *Ingestion {
+					ingestion, _ := New(firstMockClient, "test2", "test2")
+					return ingestion
+				},
+			},
+		},
+		{
+			name: "TestSameEndpoint",
+			clients: []func() *Ingestion{
+				func() *Ingestion {
+					ingestion, _ := New(firstMockClient, "test", "test")
+					return ingestion
+				},
+				func() *Ingestion {
+					ingestion, _ := New(mockClientSame, "test2", "test2")
+					return ingestion
+				},
+			},
+		},
+		{
+			name: "TestDifferentEndpoint",
+			clients: []func() *Ingestion{
+				func() *Ingestion {
+					ingestion, _ := New(firstMockClient, "test", "test")
+					return ingestion
+				},
+				func() *Ingestion {
+					ingestion, _ := New(secondMockClient, "test2", "test2")
+					return ingestion
+				},
+			},
+		},
+		{
+			name: "TestDifferentAndSameEndpoints",
+			clients: []func() *Ingestion{
+				func() *Ingestion {
+					ingestion, _ := New(firstMockClient, "test", "test")
+					return ingestion
+				},
+				func() *Ingestion {
+					ingestion, _ := New(mockClientSame, "test", "test")
+					return ingestion
+				},
+				func() *Ingestion {
+					ingestion, _ := New(secondMockClient, "test2", "test2")
+					return ingestion
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mgrMap := make(map[*resources.Manager]bool)
+			for _, client := range test.clients {
+				mgr := client().mgr
+				mgrMap[mgr] = true
+			}
+
+			if len(mgrMap) != len(test.clients) {
+				t.Errorf("Got duplicated managers, want %d managers, got %d", len(test.clients), len(mgrMap))
+			}
+		})
+	}
+}

--- a/kusto/ingest/internal/resources/resources.go
+++ b/kusto/ingest/internal/resources/resources.go
@@ -17,7 +17,7 @@ import (
 
 // mgmter is a private interface that allows us to write hermetic tests against the kusto.Client.Mgmt() method.
 type mgmter interface {
-	Mgmt(context.Context, string, kusto.Stmt, ...kusto.MgmtOption) (*kusto.RowIterator, error)
+	Mgmt(ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
 }
 
 var objectTypes = map[string]bool{
@@ -134,7 +134,7 @@ type Manager struct {
 }
 
 // New is the constructor for Manager.
-func New(client *kusto.Client) (*Manager, error) {
+func New(client mgmter) (*Manager, error) {
 	m := &Manager{client: client, done: make(chan struct{})}
 	if err := m.fetch(context.Background()); err != nil {
 		return nil, err

--- a/kusto/ingest/query_client.go
+++ b/kusto/ingest/query_client.go
@@ -1,0 +1,14 @@
+package ingest
+
+import (
+	"context"
+
+	"github.com/Azure/azure-kusto-go/kusto"
+)
+
+type QueryClient interface {
+	Auth() kusto.Authorization
+	Endpoint() string
+	Query(ctx context.Context, db string, query kusto.Stmt, options ...kusto.QueryOption) (*kusto.RowIterator, error)
+	Mgmt(ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
+}

--- a/kusto/test/etoe/etoe_env.go
+++ b/kusto/test/etoe/etoe_env.go
@@ -14,15 +14,19 @@ import (
 
 // Config represents a config.json file that must be in the directory and hold information to do the integration tests.
 type Config struct {
-	// Endpoint is the  endpoint name to connect with
+	// Endpoint is the endpoint name to connect with
 	Endpoint string
-	// Database is the name of an exisiting database that can be used for tests
+	// SecondaryEndpoint is the endpoint name to connect with for the secondary cluster
+	SecondaryEndpoint string
+	// Database is the name of an existing database that can be used for tests
 	Database string
+	// SecondaryDatabase is the name of an existing database in the secondary that can be used for tests
+	SecondaryDatabase string
 	// ClientID is the object-id of the principal authorized to connect to the database
 	ClientID string
 	// ClientSecret is the key used to get a token on behalf of the principal
 	ClientSecret string
-	// TenantID is the tenant on which the prinicpal exisets
+	// TenantID is the tenant on which the principal exists
 	TenantID string
 	// Authorizer generates bearer tokens on behalf of the principal
 	Authorizer kusto.Authorization
@@ -63,11 +67,13 @@ func init() {
 	} else {
 		// if couldn't find a config file, we try to read them from env
 		testConfig = Config{
-			Endpoint:     os.Getenv("ENGINE_CONNECTION_STRING"),
-			Database:     os.Getenv("TEST_DATABASE"),
-			ClientID:     os.Getenv("APP_ID"),
-			ClientSecret: os.Getenv("APP_KEY"),
-			TenantID:     os.Getenv("AUTH_ID"),
+			Endpoint:          os.Getenv("ENGINE_CONNECTION_STRING"),
+			SecondaryEndpoint: os.Getenv("SECONDARY_ENGINE_CONNECTION_STRING"),
+			Database:          os.Getenv("TEST_DATABASE"),
+			SecondaryDatabase: os.Getenv("SECONDARY_DATABASE"),
+			ClientID:          os.Getenv("APP_ID"),
+			ClientSecret:      os.Getenv("APP_KEY"),
+			TenantID:          os.Getenv("AUTH_ID"),
 		}
 
 		if testConfig.Endpoint == "" {


### PR DESCRIPTION
#### Pull Request Description

- Make Ingest accept an interface
- Stop caching manager as it no longer fits the design.

Currently we use a singleton resource manager for every connection. 
This was to save resources of creating one for each connection, but this was when clients didn't have endpoint or authentication.

Now that they do, it causes a bug that all ingestions will be forwarded to the first specified client endpoint and use its authentication.

This PR removes this singleton, and makes a new resource manager for each client, similar to other sdk.

In the future, it may be possible to cache these managers in a correct way, but for now that's enough for the bug.


Addtionally, ingest.New now instead of directly accepting a `kusto.Client`, now accepts an interface called `ingest.QueryClient` that contains all the relevant methods. This lets us mock the client, and might have more creative uses in the future.