### PR TITLE
Expose `TableFragmentType` via a Replace flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ defer iter.Stop()
 err = iter.Do(
 	func(row *table.Row) error {
 		if row.Replace {
-			fmt.Println("---")	// Replace flag indicates that the query result should be cleared and replaced with this row
+			fmt.Println("---") // Replace flag indicates that the query result should be cleared and replaced with this row
 		}
 		fmt.Println(row) // As a convenience, printing a *table.Row will output csv
 		return nil
@@ -106,7 +106,7 @@ err = iter.Do(
 			return err
 		}
 		if row.Replace {
-			recs = recs[:0]
+			recs = recs[:0] // Replace flag indicates that the query result should be cleared and replaced with this row
 		}
 		recs = append(recs, rec)
 		return nil

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ defer iter.Stop()
 // .Do() will call the function for every row in the table.
 err = iter.Do(
 	func(row *table.Row) error {
+		if row.Replace {
+			fmt.Println("---")	// Replace flag indicates that the query result should be cleared and replaced with this row
+		}
 		fmt.Println(row) // As a convenience, printing a *table.Row will output csv
 		return nil
 	},
@@ -101,6 +104,9 @@ err = iter.Do(
 		rec := NodeRec{}
 		if err := row.ToStruct(&rec); err != nil {
 			return err
+		}
+		if row.Replace {
+			recs = recs[:0]
 		}
 		recs = append(recs, rec)
 		return nil

--- a/kusto/data/table/table.go
+++ b/kusto/data/table/table.go
@@ -55,6 +55,8 @@ type Row struct {
 	Values value.Values
 	// Op is the operation that resulted in the row. This is for internal use.
 	Op errors.Op
+	// Replace indicates whether the existing result set should be cleared and replaced with this row.
+	Replace bool
 
 	columnNames []string
 }

--- a/kusto/doc.go
+++ b/kusto/doc.go
@@ -45,7 +45,7 @@ and accepts only string constants for arguments.
 	err = iter.Do(
 		func(row *table.Row) error {
 			if row.Replace {
-				fmt.Println("---")	// Replace flag indicates that the query result should be cleared and replaced with this row
+				fmt.Println("---") // Replace flag indicates that the query result should be cleared and replaced with this row
 			}
 			fmt.Println(row) // As a convenience, printing a *table.Row will output csv
 			return nil
@@ -82,7 +82,7 @@ Keeping our query the same, instead of printing the Rows we will simply put them
 				return err
 			}
 			if row.Replace {
-				recs = recs[:0]
+				recs = recs[:0]  // Replace flag indicates that the query result should be cleared and replaced with this row
 			}
 			recs = append(recs, rec)
 			return nil

--- a/kusto/doc.go
+++ b/kusto/doc.go
@@ -44,6 +44,9 @@ and accepts only string constants for arguments.
 	// .Do() will call the function for every row in the table.
 	err = iter.Do(
 		func(row *table.Row) error {
+			if row.Replace {
+				fmt.Println("---")	// Replace flag indicates that the query result should be cleared and replaced with this row
+			}
 			fmt.Println(row) // As a convenience, printing a *table.Row will output csv
 			return nil
 		},
@@ -77,6 +80,9 @@ Keeping our query the same, instead of printing the Rows we will simply put them
 			rec := NodeRec{}
 			if err := row.ToStruct(&rec); err != nil {
 				return err
+			}
+			if row.Replace {
+				recs = recs[:0]
 			}
 			recs = append(recs, rec)
 			return nil

--- a/kusto/kusto_examples_test.go
+++ b/kusto/kusto_examples_test.go
@@ -50,6 +50,9 @@ func Example_simple() {
 			if err := row.ToStruct(&rec); err != nil {
 				return err
 			}
+			if row.Replace {
+				recs = recs[:0]
+			}
 			recs = append(recs, rec)
 			return nil
 		},
@@ -222,6 +225,9 @@ func ExampleClient_Query_do() {
 
 	err = iter.Do(
 		func(row *table.Row) error {
+			if row.Replace {
+				fmt.Println("---") // Replace flag indicates that the query result should be cleared and replaced with this row
+			}
 			for _, v := range row.Values {
 				fmt.Printf("%s,", v)
 			}

--- a/kusto/statemachine.go
+++ b/kusto/statemachine.go
@@ -273,7 +273,7 @@ func (p *progressiveSM) fragment() (stateFn, error) {
 		select {
 		case <-p.ctx.Done():
 			return nil, p.ctx.Err()
-		case p.iter.inRows <- send{inRows: table.KustoRows, wg: p.wg}:
+		case p.iter.inRows <- send{inRows: table.KustoRows, inTableFragmentType: table.TableFragmentType, wg: p.wg}:
 		}
 	} else {
 		p.nonPrimary.Rows = append(p.nonPrimary.Rows, p.currentFrame.(v2.TableFragment).Rows...)

--- a/kusto/statemachine_test.go
+++ b/kusto/statemachine_test.go
@@ -406,6 +406,11 @@ func TestProgressive(t *testing.T) {
 							value.String{Value: "Dubovski", Valid: true},
 							value.Long{Value: 0, Valid: false},
 						},
+						{
+							value.DateTime{Value: nowish, Valid: true},
+							value.String{Value: "Evcpwtlj", Valid: true},
+							value.Long{Value: 1, Valid: true},
+						},
 					},
 					TableFragmentType: "DataReplace",
 				},
@@ -456,6 +461,19 @@ func TestProgressive(t *testing.T) {
 					},
 					Replace: true,
 					Op:      errors.OpQuery,
+				},
+				&table.Row{
+					ColumnTypes: table.Columns{
+						{Name: "Timestamp", Type: "datetime"},
+						{Name: "Name", Type: "string"},
+						{Name: "ID", Type: "long"},
+					},
+					Values: value.Values{
+						value.DateTime{Value: nowish, Valid: true},
+						value.String{Value: "Evcpwtlj", Valid: true},
+						value.Long{Value: 1, Valid: true},
+					},
+					Op: errors.OpQuery,
 				},
 			},
 			nonPrimary: map[frames.TableKind]frames.Frame{

--- a/kusto/statemachine_test.go
+++ b/kusto/statemachine_test.go
@@ -407,6 +407,7 @@ func TestProgressive(t *testing.T) {
 							value.Long{Value: 0, Valid: false},
 						},
 					},
+					TableFragmentType: "DataReplace",
 				},
 				v2.TableCompletion{},
 				v2.DataTable{
@@ -453,7 +454,8 @@ func TestProgressive(t *testing.T) {
 						value.String{Value: "Dubovski", Valid: true},
 						value.Long{Value: 0, Valid: false},
 					},
-					Op: errors.OpQuery,
+					Replace: true,
+					Op:      errors.OpQuery,
 				},
 			},
 			nonPrimary: map[frames.TableKind]frames.Frame{


### PR DESCRIPTION
#### Pull Request Description

This PR proposes a fix for #73 . Table fragments of type `DataReplace` should cause the existing result set to be replaced with new one; otherwise, the obtained query result may contain duplicated entries. To make users aware of this, this PR adds a flag called `Replace` in struct `Row` to indicate that the existing result set should be emptied before adding this row to the set.

---

#### Future Release Comment

**Breaking Changes:**
- The new `Replace` flag in struct `Row` should be handled to avoid duplicated entries in the result set. Adding the following code to handle the `Replace` flag in the `iter.Do` calls is recommended:

  ```golang
  var results []Result
  iter.Do(
	  func(row *table.Row) error {
		  // result := ...
		  if row.Replace {
			  results = results[:0]
		  }
		  results = append(results, result)
		  return nil
	  },
  )
  ```

**Fixes:**
- Fix duplicated entries caused by `TableFragmentType` (#73)
