### PR TITLE
Add support for custom http.Client

### DIFF
--- a/kusto/conn.go
+++ b/kusto/conn.go
@@ -42,8 +42,8 @@ type conn struct {
 	client                         *http.Client
 }
 
-// newConn returns a new conn object.
-func newConn(endpoint string, auth Authorization) (*conn, error) {
+// newConn returns a new conn object with an injected http.Client
+func newConn(endpoint string, auth Authorization, client *http.Client) (*conn, error) {
 	if !validURL.MatchString(endpoint) {
 		return nil, errors.ES(errors.OpServConn, errors.KClientArgs, "endpoint is not valid(%s), should be https://<cluster name>.*", endpoint).SetNoRetry()
 	}
@@ -54,13 +54,13 @@ func newConn(endpoint string, auth Authorization) (*conn, error) {
 	}
 
 	c := &conn{
+		endpoint:    endpoint,
 		auth:        auth.Authorizer,
 		endMgmt:     &url.URL{Scheme: "https", Host: u.Hostname(), Path: "/v1/rest/mgmt"},
 		endQuery:    &url.URL{Scheme: "https", Host: u.Hostname(), Path: "/v2/rest/query"},
 		streamQuery: &url.URL{Scheme: "https", Host: u.Hostname(), Path: "/v1/rest/ingest/"},
-		client:      &http.Client{},
+		client:      client,
 	}
-
 	return c, nil
 }
 

--- a/kusto/kusto_examples_test.go
+++ b/kusto/kusto_examples_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -143,6 +145,26 @@ func ExampleAuthorization_config() {
 	}
 }
 
+func ExampleCustomHttpClient() {
+	// Create an authorizer with your Azure ClientID, Secret and TenantID.
+	authorizer := Authorization{
+		Config: auth.NewClientCredentialsConfig("clientID", "clientSecret", "tenantID"),
+	}
+	httpClient := &http.Client{}
+	url, err := url.Parse("squid-proxy.corp.mycompany.com:2323")
+	if err != nil {
+		panic(err.Error())
+	}
+
+	httpClient.Transport = &http.Transport{Proxy: http.ProxyURL(url)}
+
+	// Normally here you take a client.
+	_, err = NewWithCustomHttp("endpoint", authorizer, httpClient)
+	if err != nil {
+		panic(err.Error())
+	}
+}
+
 func ExampleAuthorization_msi() {
 	// Create an authorizer with an Azure MSI (managed identities).
 	msi := auth.NewMSIConfig()
@@ -156,6 +178,7 @@ func ExampleAuthorization_msi() {
 	if err != nil {
 		panic("add error handling")
 	}
+
 }
 
 func ExampleClient_Query_rows() {


### PR DESCRIPTION
#### Pull Request Description

Users need to be able to specify/configure http settings like
proxy & custom retries, which are only avaiable to set by exposing
http.Client as something the user can customize. For example,
in enterprise boxes, deployments may not have access to internet
and need to go through squid proxy. Setting HTTPS_PROXY is invasive,
as it forces other http clients to disable proxy in transport or edit NO_PROXY
in such a way that specific dns suffix are disabled. Furthermore, even if HTTPS_PROXY 
is specified, some proxy requires users to specify certs/authorization header.

#### Future Release Comment
package `github.com/azure-kusto-go/kusto` supports `NewWithCustomHttp` allowing users to instantiate
a query Kusto client with http customizations.

**Breaking Changes:**
- None

**Features:**
- This addresses https://github.com/Azure/azure-kusto-go/issues/46 from a code perspective

**Fixes:**
- None
