### PR TITLE
Added custom http option

### DIFF
--- a/kusto/conn.go
+++ b/kusto/conn.go
@@ -42,8 +42,8 @@ type conn struct {
 	client                         *http.Client
 }
 
-// newConn returns a new conn object.
-func newConn(endpoint string, auth Authorization) (*conn, error) {
+// newConn returns a new conn object with an injected http.Client
+func newConn(endpoint string, auth Authorization, client *http.Client) (*conn, error) {
 	if !validURL.MatchString(endpoint) {
 		return nil, errors.ES(errors.OpServConn, errors.KClientArgs, "endpoint is not valid(%s), should be https://<cluster name>.*", endpoint).SetNoRetry()
 	}
@@ -58,7 +58,7 @@ func newConn(endpoint string, auth Authorization) (*conn, error) {
 		endMgmt:     &url.URL{Scheme: "https", Host: u.Hostname(), Path: "/v1/rest/mgmt"},
 		endQuery:    &url.URL{Scheme: "https", Host: u.Hostname(), Path: "/v2/rest/query"},
 		streamQuery: &url.URL{Scheme: "https", Host: u.Hostname(), Path: "/v1/rest/ingest/"},
-		client:      &http.Client{},
+		client:      client,
 	}
 
 	return c, nil

--- a/kusto/ingest/ingest.go
+++ b/kusto/ingest/ingest.go
@@ -224,7 +224,7 @@ func (i *Ingestion) getStreamConn() (*conn.Conn, error) {
 		return i.streamConn, nil
 	}
 
-	sc, err := conn.New(i.client.Endpoint(), i.client.Auth())
+	sc, err := conn.New(i.client.Endpoint(), i.client.Auth(), i.client.HttpClient())
 	if err != nil {
 		return nil, err
 	}

--- a/kusto/ingest/ingest_test.go
+++ b/kusto/ingest/ingest_test.go
@@ -2,6 +2,7 @@ package ingest
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/Azure/azure-kusto-go/kusto"
@@ -15,6 +16,10 @@ type mockClient struct {
 	endpoint string
 	auth     kusto.Authorization
 	onMgmt   func(ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
+}
+
+func (m mockClient) HttpClient() *http.Client {
+	return &http.Client{}
 }
 
 func (m mockClient) Auth() kusto.Authorization {

--- a/kusto/ingest/internal/conn/conn.go
+++ b/kusto/ingest/internal/conn/conn.go
@@ -44,7 +44,7 @@ type Conn struct {
 }
 
 // New returns a new Conn object.
-func New(endpoint string, auth kusto.Authorization) (*Conn, error) {
+func New(endpoint string, auth kusto.Authorization, client *http.Client) (*Conn, error) {
 	if !validURL.MatchString(endpoint) {
 		return nil, errors.ES(
 			errors.OpServConn,
@@ -56,10 +56,10 @@ func New(endpoint string, auth kusto.Authorization) (*Conn, error) {
 		return nil, err
 	}
 
-	return newWithoutValidation(endpoint, auth)
+	return newWithoutValidation(endpoint, auth, client)
 }
 
-func newWithoutValidation(endpoint string, auth kusto.Authorization) (*Conn, error) {
+func newWithoutValidation(endpoint string, auth kusto.Authorization, client *http.Client) (*Conn, error) {
 	headers := http.Header{}
 	headers.Add("Accept", "application/json")
 	headers.Add("Accept-Encoding", "gzip,deflate")
@@ -81,7 +81,7 @@ func newWithoutValidation(endpoint string, auth kusto.Authorization) (*Conn, err
 		baseURL:     &url.URL{Scheme: u.Scheme, Host: u.Host, Path: "/v1/rest/ingest/"},
 		reqHeaders:  headers,
 		headersPool: make(chan http.Header, 100),
-		client:      &http.Client{},
+		client:      client,
 	}
 
 	// Fills a pool of headers to alleviate header copying timing at request time.

--- a/kusto/ingest/internal/conn/conn_test.go
+++ b/kusto/ingest/internal/conn/conn_test.go
@@ -165,7 +165,7 @@ func TestStream(t *testing.T) {
 			time.Sleep(10 * time.Millisecond)
 
 			fmt.Println(server.port)
-			conn, err := newWithoutValidation(fmt.Sprintf("http://127.0.0.1:%d", server.port), kusto.Authorization{})
+			conn, err := newWithoutValidation(fmt.Sprintf("http://127.0.0.1:%d", server.port), kusto.Authorization{}, &http.Client{})
 			if err != nil {
 				panic(err)
 			}

--- a/kusto/ingest/query_client.go
+++ b/kusto/ingest/query_client.go
@@ -2,6 +2,7 @@ package ingest
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/Azure/azure-kusto-go/kusto"
 )
@@ -11,4 +12,5 @@ type QueryClient interface {
 	Endpoint() string
 	Query(ctx context.Context, db string, query kusto.Stmt, options ...kusto.QueryOption) (*kusto.RowIterator, error)
 	Mgmt(ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
+	HttpClient() *http.Client
 }

--- a/kusto/ingest/streaming.go
+++ b/kusto/ingest/streaming.go
@@ -31,7 +31,7 @@ var FileIsBlobErr = errors.ES(errors.OpIngestStream, errors.KClientArgs, "blobst
 // More information can be found here:
 // https://docs.microsoft.com/en-us/azure/kusto/management/create-ingestion-mapping-command
 func NewStreaming(client QueryClient, db, table string) (*Streaming, error) {
-	streamConn, err := conn.New(client.Endpoint(), client.Auth())
+	streamConn, err := conn.New(client.Endpoint(), client.Auth(), client.HttpClient())
 	if err != nil {
 		return nil, err
 	}

--- a/kusto/kusto.go
+++ b/kusto/kusto.go
@@ -427,3 +427,7 @@ func (*Client) contextSetup(ctx context.Context, mgmtCall bool) (context.Context
 	ctx, cancel := context.WithTimeout(ctx, 4*time.Minute)
 	return ctx, cancel, nil
 }
+
+func (c *Client) HttpClient() *http.Client {
+	return c.http
+}

--- a/kusto/kusto_examples_test.go
+++ b/kusto/kusto_examples_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -305,4 +307,24 @@ func ExampleClient_Query_struct() {
 	}()
 
 	wg.Wait()
+}
+
+func ExampleCustomHttpClient() {
+	// Create an authorizer with your Azure ClientID, Secret and TenantID.
+	authorizer := Authorization{
+		Config: auth.NewClientCredentialsConfig("clientID", "clientSecret", "tenantID"),
+	}
+	httpClient := &http.Client{}
+	url, err := url.Parse("squid-proxy.corp.mycompany.com:2323")
+	if err != nil {
+		panic(err.Error())
+	}
+
+	httpClient.Transport = &http.Transport{Proxy: http.ProxyURL(url)}
+
+	// Normally here you take a client.
+	_, err = New("endpoint", authorizer, WithHttpClient(httpClient))
+	if err != nil {
+		panic(err.Error())
+	}
 }

--- a/kusto/mock.go
+++ b/kusto/mock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"reflect"
 	"sync"
 
@@ -157,5 +158,6 @@ func NewMockClient() *Client {
 		endpoint:   "https://sdkse2etest.eastus.kusto.windows.net",
 		auth:       Authorization{Authorizer: autorest.NewBasicAuthorizer("", "")},
 		mu:         sync.Mutex{},
+		http:       &http.Client{},
 	}
 }


### PR DESCRIPTION
#### Pull Request Description

Users need to be able to specify/configure http settings like
proxy & custom retries, which are only avaiable to set by exposing
http.Client as something the user can customize. For example,
in enterprise boxes, deployments may not have access to internet
and need to go through squid proxy. Setting HTTPS_PROXY is invasive,
as it forces other http clients to disable proxy in transport or edit NO_PROXY
in such a way that specific dns suffix are disabled. Furthermore, even if HTTPS_PROXY 
is specified, some proxy requires users to specify certs/authorization header.

#### Future Release Comment
package `github.com/azure-kusto-go/kusto` supports `NewWithCustomHttp` allowing users to instantiate
a query Kusto client with http customizations.

**Breaking Changes:**
- None

**Features:**
- This addresses https://github.com/Azure/azure-kusto-go/issues/46 from a code perspective

**Fixes:**
- None
