### PR TITLE
Make clients closeable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ client, err := kusto.New(endpoint, authorizer)
 if err != nil {
 	panic("add error handling")
 }
+// Be sure to close the client when you're done. (Error handling omitted for brevity.)
+defer client.Close()
 ```
 endpoint represents the Kusto endpoint. This will resemble: "https://<instance>.<region>.kusto.windows.net".
 
@@ -174,6 +176,8 @@ in, err := ingest.New(kustoClient, "database", "table")
 if err != nil {
 	panic("add error handling")
 }
+// Be sure to close the ingestor when you're done. (Error handling omitted for brevity.)
+defer in.Close()
 ```
 
 #### From a File

--- a/kusto/conn.go
+++ b/kusto/conn.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -200,4 +201,12 @@ func (c *conn) execute(ctx context.Context, execType int, db string, query Stmt,
 	frameCh := dec.Decode(ctx, body, op)
 
 	return execResp{reqHeader: header, respHeader: resp.Header, frameCh: frameCh}, nil
+}
+
+func (c *conn) Close() error {
+	if closer, ok := c.auth.(io.Closer); ok {
+		return closer.Close()
+	}
+
+	return nil
 }

--- a/kusto/data/errors/errors.go
+++ b/kusto/data/errors/errors.go
@@ -401,3 +401,19 @@ func GetKustoError(err error) (*Error, bool) {
 	}
 	return nil, false
 }
+
+type CombinedError struct {
+	Errors []error
+}
+
+func (c CombinedError) Error() string {
+	result := ""
+	for _, err := range c.Errors {
+		result += fmt.Sprintf("'%s';", err.Error())
+	}
+	return result
+}
+
+func GetCombinedError(errs ...error) *CombinedError {
+	return &CombinedError{Errors: errs}
+}

--- a/kusto/ingest/ingest.go
+++ b/kusto/ingest/ingest.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"sync"
 
+	"github.com/Azure/azure-kusto-go/kusto/data/errors"
 	"github.com/Azure/azure-kusto-go/kusto/ingest/internal/conn"
 	"github.com/Azure/azure-kusto-go/kusto/ingest/internal/properties"
 	"github.com/Azure/azure-kusto-go/kusto/ingest/internal/queued"
@@ -251,7 +252,7 @@ func (i *Ingestion) Close() error {
 		if err == nil {
 			err = err2
 		} else {
-			err = fmt.Errorf("combined error: %v %v", err, err2)
+			err = errors.GetCombinedError(err, err2)
 		}
 	}
 	return err

--- a/kusto/ingest/ingest_example_test.go
+++ b/kusto/ingest/ingest_example_test.go
@@ -29,11 +29,16 @@ func ExampleIngestion_FromFile() {
 	if err != nil {
 		// Do something
 	}
+	// Be sure to close the client when you're done. (Error handling omitted for brevity.)
+	defer client.Close()
 
 	ingestor, err := ingest.New(client, "database", "table")
 	if err != nil {
 		// Do something
 	}
+	// Closing the ingestor will not close the client (since the client may be used separately),
+	//but it is still important to close the ingestor when you're done.
+	defer ingestor.Close()
 
 	// Setup a maximum time for completion to be 10 minutes.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)

--- a/kusto/ingest/ingest_test.go
+++ b/kusto/ingest/ingest_test.go
@@ -17,6 +17,10 @@ type mockClient struct {
 	onMgmt   func(ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
 }
 
+func (m mockClient) Close() error {
+	return nil
+}
+
 func (m mockClient) Auth() kusto.Authorization {
 	return m.auth
 }

--- a/kusto/ingest/internal/conn/conn.go
+++ b/kusto/ingest/internal/conn/conn.go
@@ -179,3 +179,8 @@ func copyHeaders(header http.Header) http.Header {
 	}
 	return headers
 }
+
+func (c *Conn) Close() error {
+	close(c.headersPool)
+	return nil
+}

--- a/kusto/ingest/internal/conn/conn.go
+++ b/kusto/ingest/internal/conn/conn.go
@@ -189,13 +189,11 @@ func copyHeaders(header http.Header) http.Header {
 }
 
 func (c *Conn) Close() error {
-	for {
-		select {
-		case <-c.done:
-			return nil
-		default:
-			close(c.done)
-			return nil
-		}
+	select {
+	case <-c.done:
+		return nil
+	default:
+		close(c.done)
+		return nil
 	}
 }

--- a/kusto/ingest/internal/conn/conn.go
+++ b/kusto/ingest/internal/conn/conn.go
@@ -195,7 +195,6 @@ func (c *Conn) Close() error {
 			return nil
 		default:
 			close(c.done)
-			close(c.headersPool)
 			return nil
 		}
 	}

--- a/kusto/ingest/internal/conn/conn.go
+++ b/kusto/ingest/internal/conn/conn.go
@@ -194,8 +194,8 @@ func (c *Conn) Close() error {
 		case <-c.done:
 			return nil
 		default:
-			close(c.headersPool)
 			close(c.done)
+			close(c.headersPool)
 			return nil
 		}
 	}

--- a/kusto/ingest/internal/conn/conn.go
+++ b/kusto/ingest/internal/conn/conn.go
@@ -83,6 +83,7 @@ func newWithoutValidation(endpoint string, auth kusto.Authorization) (*Conn, err
 		reqHeaders:  headers,
 		headersPool: make(chan http.Header, 100),
 		client:      &http.Client{},
+		done:        make(chan struct{}),
 	}
 
 	// Fills a pool of headers to alleviate header copying timing at request time.

--- a/kusto/ingest/internal/queued/queued.go
+++ b/kusto/ingest/internal/queued/queued.go
@@ -39,6 +39,7 @@ const (
 
 // Queued provides methods for taking data from various sources and ingesting it into Kusto using queued ingestion.
 type Queued interface {
+	io.Closer
 	Local(ctx context.Context, from string, props properties.All) error
 	Reader(ctx context.Context, reader io.Reader, props properties.All) (string, error)
 	Blob(ctx context.Context, from string, fileSize int64, props properties.All) error
@@ -435,4 +436,10 @@ func IsLocalPath(s string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func (i *Ingestion) Close() error {
+	i.mgr.Close()
+	i.transferManager.Close()
+	return nil
 }

--- a/kusto/ingest/internal/resources/resources.go
+++ b/kusto/ingest/internal/resources/resources.go
@@ -154,8 +154,14 @@ func New(client mgmter) (*Manager, error) {
 
 // Close closes the manager. This stops any token refreshes.
 func (m *Manager) Close() {
-	if _, ok := <-m.done; !ok {
-		close(m.done)
+	for {
+		select {
+		case <-m.done:
+			return
+		default:
+			close(m.done)
+			return
+		}
 	}
 }
 

--- a/kusto/ingest/internal/resources/resources.go
+++ b/kusto/ingest/internal/resources/resources.go
@@ -154,7 +154,9 @@ func New(client mgmter) (*Manager, error) {
 
 // Close closes the manager. This stops any token refreshes.
 func (m *Manager) Close() {
-	close(m.done)
+	if _, ok := <-m.done; !ok {
+		close(m.done)
+	}
 }
 
 func (m *Manager) renewResources() {

--- a/kusto/ingest/internal/resources/test_helpers.go
+++ b/kusto/ingest/internal/resources/test_helpers.go
@@ -125,6 +125,10 @@ type FsMock struct {
 	OnBlob   func(ctx context.Context, from string, fileSize int64, props properties.All) error
 }
 
+func (f FsMock) Close() error {
+	return nil
+}
+
 func (f FsMock) Local(ctx context.Context, from string, props properties.All) error {
 	if f.OnLocal != nil {
 		return f.OnLocal(ctx, from, props)

--- a/kusto/ingest/managed.go
+++ b/kusto/ingest/managed.go
@@ -154,7 +154,7 @@ func (m *Managed) Close() error {
 	if err == nil {
 		err = err2
 	} else {
-		err = fmt.Errorf("combined error: %v %v", err, err2)
+		err = errors.GetCombinedError(err, err2)
 	}
 	return nil
 }

--- a/kusto/ingest/managed.go
+++ b/kusto/ingest/managed.go
@@ -146,3 +146,15 @@ func (m *Managed) newProp() properties.All {
 		},
 	}
 }
+
+func (m *Managed) Close() error {
+	var err error
+	err = m.queued.Close()
+	err2 := m.streaming.Close()
+	if err == nil {
+		err = err2
+	} else {
+		err = fmt.Errorf("combined error: %v %v", err, err2)
+	}
+	return nil
+}

--- a/kusto/ingest/query_client.go
+++ b/kusto/ingest/query_client.go
@@ -2,11 +2,13 @@ package ingest
 
 import (
 	"context"
+	"io"
 
 	"github.com/Azure/azure-kusto-go/kusto"
 )
 
 type QueryClient interface {
+	io.Closer
 	Auth() kusto.Authorization
 	Endpoint() string
 	Query(ctx context.Context, db string, query kusto.Stmt, options ...kusto.QueryOption) (*kusto.RowIterator, error)

--- a/kusto/ingest/query_client.go
+++ b/kusto/ingest/query_client.go
@@ -2,8 +2,8 @@ package ingest
 
 import (
 	"context"
-	"net/http"
 	"io"
+	"net/http"
 
 	"github.com/Azure/azure-kusto-go/kusto"
 )

--- a/kusto/ingest/streaming.go
+++ b/kusto/ingest/streaming.go
@@ -156,6 +156,6 @@ func (i *Streaming) newProp() properties.All {
 	}
 }
 
-func (s Streaming) Close() error {
-	return s.streamConn.Close()
+func (i *Streaming) Close() error {
+	return i.streamConn.Close()
 }

--- a/kusto/ingest/streaming.go
+++ b/kusto/ingest/streaming.go
@@ -14,6 +14,7 @@ import (
 )
 
 type streamIngestor interface {
+	io.Closer
 	StreamIngest(ctx context.Context, db, table string, payload io.Reader, format properties.DataFormat, mappingName string, clientRequestId string) error
 }
 
@@ -153,4 +154,8 @@ func (i *Streaming) newProp() properties.All {
 			ClientRequestId: "KGC.executeStreaming;" + uuid.New().String(),
 		},
 	}
+}
+
+func (s Streaming) Close() error {
+	return s.streamConn.Close()
 }

--- a/kusto/ingest/streaming_test.go
+++ b/kusto/ingest/streaming_test.go
@@ -27,6 +27,10 @@ type fakeStreamIngestor struct {
 	onStreamIngest streamIngestFunc
 }
 
+func (f fakeStreamIngestor) Close() error {
+	return nil
+}
+
 func (f fakeStreamIngestor) StreamIngest(ctx context.Context, db, table string, payload io.Reader, format properties.DataFormat, mappingName string, clientRequestId string) error {
 	return f.onStreamIngest(ctx, db, table, payload, format, mappingName, clientRequestId)
 }

--- a/kusto/kusto.go
+++ b/kusto/kusto.go
@@ -2,6 +2,8 @@ package kusto
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"net/url"
 	"reflect"
 	"strings"
@@ -18,6 +20,7 @@ import (
 
 // queryer provides for getting a stream of Kusto frames. Exists to allow fake Kusto streams in tests.
 type queryer interface {
+	io.Closer
 	query(ctx context.Context, db string, query Stmt, options *queryOptions) (execResp, error)
 	mgmt(ctx context.Context, db string, query Stmt, options *mgmtOptions) (execResp, error)
 }
@@ -414,4 +417,20 @@ func (*Client) contextSetup(ctx context.Context, mgmtCall bool) (context.Context
 	}
 	ctx, cancel := context.WithTimeout(ctx, 4*time.Minute)
 	return ctx, cancel, nil
+}
+
+func (c *Client) Close() error {
+	var err error
+	if c.conn != nil {
+		err = c.conn.Close()
+	}
+	if c.ingestConn != nil {
+		err2 := c.ingestConn.Close()
+		if err == nil {
+			err = err2
+		} else {
+			err = fmt.Errorf("combined error: %v %v", err, err2)
+		}
+	}
+	return err
 }

--- a/kusto/kusto.go
+++ b/kusto/kusto.go
@@ -2,9 +2,9 @@ package kusto
 
 import (
 	"context"
-	"net/http"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"reflect"
 	"strings"

--- a/kusto/kusto.go
+++ b/kusto/kusto.go
@@ -2,7 +2,6 @@ package kusto
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -445,7 +444,7 @@ func (c *Client) Close() error {
 		if err == nil {
 			err = err2
 		} else {
-			err = fmt.Errorf("combined error: %v %v", err, err2)
+			err = errors.GetCombinedError(err, err2)
 		}
 	}
 	return err

--- a/kusto/kusto_examples_test.go
+++ b/kusto/kusto_examples_test.go
@@ -33,6 +33,9 @@ func Example_simple() {
 		panic("add error handling")
 	}
 
+	// Be sure to close the client when you're done. (Error handling omitted for brevity.)
+	defer client.Close()
+
 	ctx := context.Background()
 
 	// Query our database table "systemNodes" for the CollectionTimes and the NodeIds.
@@ -105,6 +108,8 @@ func Example_complex() {
 	if err != nil {
 		panic("add error handling")
 	}
+	// Be sure to close the client when you're done. (Error handling omitted for brevity.)
+	defer client.Close()
 
 	ctx := context.Background()
 
@@ -167,6 +172,8 @@ func ExampleClient_Query_rows() {
 	if err != nil {
 		panic("add error handling")
 	}
+	// Be sure to close the client when you're done. (Error handling omitted for brevity.)
+	defer client.Close()
 
 	ctx := context.Background()
 
@@ -210,6 +217,8 @@ func ExampleClient_Query_do() {
 	if err != nil {
 		panic("add error handling")
 	}
+	// Be sure to close the client when you're done. (Error handling omitted for brevity.)
+	defer client.Close()
 
 	ctx := context.Background()
 
@@ -263,6 +272,8 @@ func ExampleClient_Query_struct() {
 	if err != nil {
 		panic("add error handling")
 	}
+	// Be sure to close the client when you're done. (Error handling omitted for brevity.)
+	defer client.Close()
 
 	ctx := context.Background()
 

--- a/kusto/mock.go
+++ b/kusto/mock.go
@@ -135,6 +135,10 @@ func (m *MockRows) Error(err error) error {
 type mockConn struct {
 }
 
+func (m mockConn) Close() error {
+	return nil
+}
+
 func (m mockConn) query(_ context.Context, _ string, _ Stmt, _ *queryOptions) (execResp, error) {
 	return execResp{}, nil
 }

--- a/kusto/test/etoe/etoe_test.go
+++ b/kusto/test/etoe/etoe_test.go
@@ -111,7 +111,9 @@ func TestQueries(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
+		t.Log("Closing client")
 		require.NoError(t, client.Close())
+		t.Log("Closed client")
 	})
 
 	pCountStmt := kusto.NewStmt("table(tableName) | count").MustDefinitions(
@@ -408,7 +410,9 @@ func TestFileIngestion(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
+		t.Log("Closing client")
 		require.NoError(t, client.Close())
+		t.Log("Closed client")
 	})
 
 	queuedTable := "goe2e_queued_file_logs"
@@ -420,7 +424,9 @@ func TestFileIngestion(t *testing.T) {
 		panic(err)
 	}
 	t.Cleanup(func() {
+		t.Log("Closing queuedIngestor")
 		require.NoError(t, queuedIngestor.Close())
+		t.Log("Closed queuedIngestor")
 	})
 
 	streamingIngestor, err := ingest.NewStreaming(client, testConfig.Database, streamingTable)
@@ -429,7 +435,9 @@ func TestFileIngestion(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
+		t.Log("Closing streamingIngestor")
 		require.NoError(t, streamingIngestor.Close())
+		t.Log("Closed streamingIngestor")
 	})
 
 	managedIngestor, err := ingest.NewManaged(client, testConfig.Database, managedTable)
@@ -438,7 +446,9 @@ func TestFileIngestion(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
+		t.Log("Closing managedIngestor")
 		require.NoError(t, managedIngestor.Close())
+		t.Log("Closed managedIngestor")
 	})
 
 	mockRows := createMockLogRows()
@@ -780,7 +790,9 @@ func TestReaderIngestion(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
+		t.Log("Closing client")
 		require.NoError(t, client.Close())
+		t.Log("Closed client")
 	})
 
 	queuedIngestor, err := ingest.New(client, testConfig.Database, queuedTable)
@@ -789,7 +801,9 @@ func TestReaderIngestion(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
+		t.Log("Closing queuedIngestor")
 		require.NoError(t, queuedIngestor.Close())
+		t.Log("Closed queuedIngestor")
 	})
 
 	streamingIngestor, err := ingest.NewStreaming(client, testConfig.Database, streamingTable)
@@ -798,7 +812,9 @@ func TestReaderIngestion(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
+		t.Log("Closing streamingIngestor")
 		require.NoError(t, streamingIngestor.Close())
+		t.Log("Closed streamingIngestor")
 	})
 
 	managedIngestor, err := ingest.NewManaged(client, testConfig.Database, managedTable)
@@ -807,7 +823,9 @@ func TestReaderIngestion(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
+		t.Log("Closing managedIngestor")
 		require.NoError(t, managedIngestor.Close())
+		t.Log("Closed managedIngestor")
 	})
 
 	mockRows := createMockLogRows()
@@ -1111,7 +1129,9 @@ func TestMultipleClusters(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
+		t.Log("Closing client")
 		require.NoError(t, client.Close())
+		t.Log("Closed client")
 	})
 
 	secondaryClient, err := kusto.New(testConfig.SecondaryEndpoint, testConfig.Authorizer)
@@ -1120,7 +1140,9 @@ func TestMultipleClusters(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
+		t.Log("Closing secondaryClient")
 		require.NoError(t, secondaryClient.Close())
+		t.Log("Closed secondaryClient")
 	})
 
 	queuedTable := "goe2e_queued_multiple_logs"
@@ -1133,7 +1155,9 @@ func TestMultipleClusters(t *testing.T) {
 		panic(err)
 	}
 	t.Cleanup(func() {
+		t.Log("Closing queuedIngestor")
 		require.NoError(t, queuedIngestor.Close())
+		t.Log("Closed queuedIngestor")
 	})
 
 	streamingIngestor, err := ingest.NewStreaming(client, testConfig.Database, streamingTable)
@@ -1142,7 +1166,9 @@ func TestMultipleClusters(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
+		t.Log("Closing streamingIngestor")
 		require.NoError(t, streamingIngestor.Close())
+		t.Log("Closed streamingIngestor")
 	})
 
 	secondaryQueuedIngestor, err := ingest.New(secondaryClient, testConfig.SecondaryDatabase, queuedTable)
@@ -1151,7 +1177,9 @@ func TestMultipleClusters(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
+		t.Log("Closing secondaryQueuedIngestor")
 		require.NoError(t, secondaryQueuedIngestor.Close())
+		t.Log("Closed secondaryQueuedIngestor")
 	})
 
 	secondaryStreamingIngestor, err := ingest.NewStreaming(secondaryClient, testConfig.SecondaryDatabase, streamingTable)
@@ -1159,7 +1187,9 @@ func TestMultipleClusters(t *testing.T) {
 		panic(err)
 	}
 	t.Cleanup(func() {
+		t.Log("Closing secondaryStreamingIngestor")
 		require.NoError(t, secondaryStreamingIngestor.Close())
+		t.Log("Closed secondaryStreamingIngestor")
 	})
 
 	tests := []struct {
@@ -1304,7 +1334,9 @@ func TestStreamingIngestion(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
+		t.Log("Closing client")
 		require.NoError(t, client.Close())
+		t.Log("Closed client")
 	})
 
 	tableName := fmt.Sprintf("goe2e_streaming_datatypes_%d", time.Now().Unix())
@@ -1369,7 +1401,9 @@ func TestStreamingIngestion(t *testing.T) {
 
 			ingestor, err := ingest.New(client, testConfig.Database, tableName)
 			t.Cleanup(func() {
+				t.Log("Closing ingestor")
 				require.NoError(t, ingestor.Close())
+				t.Log("Closed ingestor")
 			})
 
 			if err != nil {
@@ -1411,7 +1445,9 @@ func TestError(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
+		t.Log("Closing client")
 		require.NoError(t, client.Close())
+		t.Log("Closed client")
 	})
 
 	_, err = client.Query(context.Background(), testConfig.Database, pCountStmt.MustParameters(


### PR DESCRIPTION
#### Pull Request Description

Make clients (both clients and ingest clients) closeable, so users could free their resources when done using them.
---

#### Future Release Comment
_[Add description of your change, to include in the next release]_
_[Delete any or all irrelevant sections, e.g. if your change does not warrant a release comment at all]_

**Breaking Changes:**
- None

**Features:**
- Make clients (both clients and ingest clients) closeable, so users could free their resources when done using them.

**Fixes:**
- None
