### PR TITLE
Add retry mechanism for throttled requests

### DIFF
--- a/kusto/conn.go
+++ b/kusto/conn.go
@@ -183,7 +183,11 @@ func (c *conn) execute(ctx context.Context, execType int, db string, query Stmt,
 		return execResp{}, err
 	}
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return execResp{}, errors.HTTPErrorCode(op, resp.StatusCode, body, fmt.Sprintf("request got throttled for query %q: ", query.String()))
+	}
+
+	if resp.StatusCode != http.StatusOK {
 		return execResp{}, errors.HTTP(op, resp.Status, body, fmt.Sprintf("error from Kusto endpoint for query %q: ", query.String()))
 	}
 

--- a/kusto/ingest/internal/resources/resources.go
+++ b/kusto/ingest/internal/resources/resources.go
@@ -13,7 +13,15 @@ import (
 	"time"
 
 	"github.com/Azure/azure-kusto-go/kusto"
+	kustoErrors "github.com/Azure/azure-kusto-go/kusto/data/errors"
 	"github.com/Azure/azure-kusto-go/kusto/data/table"
+	"github.com/cenkalti/backoff/v4"
+)
+
+const (
+	defaultInitialInterval = 1 * time.Second
+	defaultMultiplier      = 2
+	retryCount             = 4
 )
 
 // mgmter is a private interface that allows us to write hermetic tests against the kusto.Client.Mgmt() method.
@@ -179,7 +187,23 @@ func (m *Manager) AuthContext(ctx context.Context) (string, error) {
 		return m.kustoToken.AuthContext, nil
 	}
 
-	rows, err := m.client.Mgmt(ctx, "NetDefaultDB", kusto.NewStmt(".get kusto identity token"), kusto.IngestionEndpoint())
+	var rows *kusto.RowIterator
+	retryCtx := backoff.WithContext(InitBackoff(), ctx)
+	err := backoff.Retry(func() error {
+		var err error
+		rows, err = m.client.Mgmt(ctx, "NetDefaultDB", kusto.NewStmt(".get kusto identity token"), kusto.IngestionEndpoint())
+		if err == nil {
+			return nil
+		}
+		if httpErr, ok := err.(*kustoErrors.HttpError); ok {
+			// only retry in case of throttling
+			if httpErr.IsThrottled() {
+				return err
+			}
+		}
+		return backoff.Permanent(err)
+	}, retryCtx)
+
 	if err != nil {
 		return "", fmt.Errorf("problem getting authorization context from Kusto via Mgmt: %s", err)
 	}
@@ -247,7 +271,24 @@ func (i *Ingestion) importRec(rec ingestResc) error {
 func (m *Manager) fetch(ctx context.Context) error {
 	m.fetchLock.Lock()
 	defer m.fetchLock.Unlock()
-	rows, err := m.client.Mgmt(ctx, "NetDefaultDB", kusto.NewStmt(".get ingestion resources"), kusto.IngestionEndpoint())
+
+	var rows *kusto.RowIterator
+	retryCtx := backoff.WithContext(InitBackoff(), ctx)
+	err := backoff.Retry(func() error {
+		var err error
+		rows, err = m.client.Mgmt(ctx, "NetDefaultDB", kusto.NewStmt(".get ingestion resources"), kusto.IngestionEndpoint())
+		if err == nil {
+			return nil
+		}
+		if httpErr, ok := err.(*kustoErrors.HttpError); ok {
+			// only retry in case of throttling
+			if httpErr.IsThrottled() {
+				return err
+			}
+		}
+		return backoff.Permanent(err)
+	}, retryCtx)
+
 	if err != nil {
 		return fmt.Errorf("problem getting ingestion resources from Kusto: %s", err)
 	}
@@ -304,4 +345,11 @@ func (m *Manager) Resources() (Ingestion, error) {
 		return Ingestion{}, fmt.Errorf("manager has not retrieved an Ingestion object yet")
 	}
 	return i, nil
+}
+
+func InitBackoff() backoff.BackOff {
+	exp := backoff.NewExponentialBackOff()
+	exp.InitialInterval = defaultInitialInterval
+	exp.Multiplier = defaultMultiplier
+	return backoff.WithMaxRetries(exp, retryCount)
 }


### PR DESCRIPTION
Use exponential backoff to retry throttled requests.
