### PR TITLE
Fix Column.Type assignment. Was using string, now using types. Column value

### DIFF
--- a/kusto/internal/frames/v1/v1.go
+++ b/kusto/internal/frames/v1/v1.go
@@ -35,22 +35,24 @@ type DataType struct {
 	DataType   string
 }
 
+func (dt DataType) rawType() string {
+	if dt.ColumnType != "" {
+		return dt.ColumnType
+	}
+	return dt.DataType
+}
+
 func (dt DataType) toColumn() (table.Column, error) {
 	col := table.Column{Name: dt.ColumnName}
 
-	if dt.ColumnType != "" {
-		var ok bool
-		col.Type, ok = translate[strings.ToLower(dt.ColumnType)]
-		if !ok {
-			return col, errors.ES(errors.OpMgmt, errors.KInternal, "DataTable.Columns(v1) had string entry with .ColumnType set to %s, which is not supported", dt.ColumnType)
-		}
-		return col, nil
+	if dt.rawType() == "" {
+		return col, errors.ES(errors.OpMgmt, errors.KInternal, "DataTable.Columns(v1) did not have ColumnType or DataType provided")
 	}
 
 	var ok bool
-	col.Type, ok = translate[strings.ToLower(dt.DataType)]
+	col.Type, ok = translate[strings.ToLower(dt.rawType())]
 	if !ok {
-		return col, errors.ES(errors.OpMgmt, errors.KInternal, "DataTable.Columns(v1) had entry with .DataType set to %q type, which is not supported", dt.DataType)
+		return col, errors.ES(errors.OpMgmt, errors.KInternal, "DataTable.Columns(v1) had string entry with either .ColumnType/.DataType set to %s, which is not supported", dt.rawType())
 	}
 	return col, nil
 }

--- a/kusto/internal/frames/v1/v1.go
+++ b/kusto/internal/frames/v1/v1.go
@@ -39,7 +39,11 @@ func (dt DataType) toColumn() (table.Column, error) {
 	col := table.Column{Name: dt.ColumnName}
 
 	if dt.ColumnType != "" {
-		col.Type = types.Column(dt.ColumnType)
+		var ok bool
+		col.Type, ok = translate[strings.ToLower(dt.ColumnType)]
+		if !ok {
+			return col, errors.ES(errors.OpMgmt, errors.KInternal, "DataTable.Columns(v1) had string entry with .ColumnType set to %s, which is not supported", dt.ColumnType)
+		}
 		return col, nil
 	}
 

--- a/kusto/internal/frames/v1/v1_test.go
+++ b/kusto/internal/frames/v1/v1_test.go
@@ -1,0 +1,60 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-kusto-go/kusto/data/table"
+	"github.com/Azure/azure-kusto-go/kusto/data/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDataType tests for https://github.com/Azure/azure-kusto-go/issues/116
+func TestDataType(t *testing.T) {
+	tests := []struct {
+		desc string
+		dt   DataType
+		want table.Column
+		err  bool
+	}{
+		{
+			desc: "Error: ColumnType is incorrect",
+			dt:   DataType{ColumnType: "incorrect"},
+			err:  true,
+		},
+		{
+			desc: "Error: ColumnType and DataType were not set",
+			dt:   DataType{},
+			err:  true,
+		},
+		{
+			desc: "Error: DataType.DataType is incorrect",
+			dt:   DataType{DataType: "incorrect"},
+			err:  true,
+		},
+		{
+			desc: "Success: ColumnType is correct",
+			dt:   DataType{ColumnName: "someString", ColumnType: "System.String"},
+			want: table.Column{Name: "someString", Type: types.String},
+		},
+		{
+			desc: "Success: DataType is correct",
+			dt:   DataType{ColumnName: "someString", DataType: "System.String"},
+			want: table.Column{Name: "someString", Type: types.String},
+		},
+	}
+
+	for _, test := range tests {
+		got, err := test.dt.toColumn()
+		switch {
+		case err == nil && test.err:
+			t.Errorf("TestDataType(%s): got err == nil, want err != nil", test.desc)
+			continue
+		case err != nil && !test.err:
+			t.Errorf("TestDataType(%s): got err == %s, want err == nil", test.desc, err)
+			continue
+		case err != nil:
+			continue
+		}
+		require.EqualValues(t, test.want, got)
+	}
+}


### PR DESCRIPTION
#### Pull Request Description

This fixes the `v1` frame decoder bug that was resulting in the error `DataTable had column of type System.String, which was unknown`.

Fixes Azure/azure-kusto-go#116

---

#### Future Release Comment
Fixes `Mgmt(..)` query bug. Failure to unmarshall, caused by incorrect type assignment in v1 frame data.

**Fixes:**
- [Issue 116](https://github.com/Azure/azure-kusto-go/issues/116)
