### PR TITLE
Deprecate AllowWrite

### DIFF
--- a/kusto/conn.go
+++ b/kusto/conn.go
@@ -144,7 +144,7 @@ func (c *conn) doRequest(ctx context.Context, execType int, db string, query Stm
 	header.Add("Accept-Encoding", "gzip")
 	header.Add("x-ms-client-version", "Kusto.Go.Client: "+version.Kusto)
 	header.Add("Content-Type", "application/json; charset=utf-8")
-	header.Add("x-ms-client-request-id", "KGC.execute;test.false.progressive"+uuid.New().String())
+	header.Add("x-ms-client-request-id", "KGC.execute;"+uuid.New().String())
 
 	if properties.Application != "" {
 		header.Add("x-ms-app", properties.Application)

--- a/kusto/conn.go
+++ b/kusto/conn.go
@@ -69,8 +69,6 @@ type queryMsg struct {
 	Properties requestProperties `json:"properties,omitempty"`
 }
 
-var writeRE = regexp.MustCompile(`(\.set|\.append|\.set-or-append|\.set-or-replace)`)
-
 type connOptions struct {
 	queryOptions *queryOptions
 	mgmtOptions  *mgmtOptions
@@ -88,18 +86,6 @@ func (c *conn) query(ctx context.Context, db string, query Stmt, options *queryO
 
 // mgmt is used to do management queries to Kusto.
 func (c *conn) mgmt(ctx context.Context, db string, query Stmt, options *mgmtOptions) (execResp, error) {
-	if writeRE.MatchString(query.String()) {
-		if !options.canWrite {
-			return execResp{}, errors.ES(
-				errors.OpQuery,
-				errors.KClientArgs,
-				"Mgmt() attempted to do a write operation. "+
-					"This requires the AllowWrite() QueryOption to be passed. "+
-					"Please see documentation on that option before use",
-			).SetNoRetry()
-		}
-	}
-
 	return c.execute(ctx, execMgmt, db, query, *options.requestProperties)
 }
 
@@ -158,7 +144,7 @@ func (c *conn) doRequest(ctx context.Context, execType int, db string, query Stm
 	header.Add("Accept-Encoding", "gzip")
 	header.Add("x-ms-client-version", "Kusto.Go.Client: "+version.Kusto)
 	header.Add("Content-Type", "application/json; charset=utf-8")
-	header.Add("x-ms-client-request-id", "KGC.execute;"+uuid.New().String())
+	header.Add("x-ms-client-request-id", "KGC.execute;test.false.progressive"+uuid.New().String())
 
 	if properties.Application != "" {
 		header.Add("x-ms-app", properties.Application)

--- a/kusto/kusto.go
+++ b/kusto/kusto.go
@@ -356,11 +356,12 @@ func (c *Client) setQueryOptions(ctx context.Context, op errors.Op, query Stmt, 
 			Parameters: params,
 		},
 	}
-	if op == errors.OpQuery {
+	/*if op == errors.OpQuery {
 		// We want progressive frames by default for Query(), but not Mgmt() because it uses v1 framing and ingestion endpoints
 		// do not support it.
 		opt.requestProperties.Options["results_progressive_enabled"] = true
-	}
+	}*/
+	opt.requestProperties.Options["results_progressive_enabled"] = true
 
 	for _, o := range options {
 		if err := o(opt); err != nil {

--- a/kusto/mgmtopts.go
+++ b/kusto/mgmtopts.go
@@ -9,14 +9,12 @@ import (
 
 type mgmtOptions struct {
 	requestProperties *requestProperties
-	canWrite          bool
 	queryIngestion    bool
 }
 
-// AllowWrite allows a query that attempts to modify data in a table.
+// Deprecated: Writing mode is now the default. Use the `RequestReadonly` option to make a read-only request.
 func AllowWrite() MgmtOption {
 	return func(m *mgmtOptions) error {
-		m.canWrite = true
 		return nil
 	}
 }

--- a/kusto/test/etoe/etoe_test.go
+++ b/kusto/test/etoe/etoe_test.go
@@ -1729,7 +1729,7 @@ func createStringyLogsData() string {
 
 func executeCommands(client *kusto.Client, database string, commandsToRun ...kusto.Stmt) error {
 	for _, cmd := range commandsToRun {
-		if _, err := client.Mgmt(context.Background(), database, cmd, kusto.AllowWrite()); err != nil {
+		if _, err := client.Mgmt(context.Background(), database, cmd); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Deprecate AllowWrite, make it the default like in other SDKs.
We still have the readonly query opt.