### PR TITLE
Remove locks where not needed

### DIFF
--- a/kusto/kusto.go
+++ b/kusto/kusto.go
@@ -195,12 +195,12 @@ const (
 // Note that the server has a timeout of 4 minutes for a query by default unless the context deadline is set. Queries can
 // take a maximum of 1 hour.
 func (c *Client) Query(ctx context.Context, db string, query Stmt, options ...QueryOption) (*RowIterator, error) {
-	ctx, cancel, err := c.contextSetup(ctx, false) // Note: cancel is called when *RowIterator has Stop() called.
+	ctx, cancel, err := contextSetup(ctx, false) // Note: cancel is called when *RowIterator has Stop() called.
 	if err != nil {
 		return nil, err
 	}
 
-	opts, err := c.setQueryOptions(ctx, errors.OpQuery, query, options...)
+	opts, err := setQueryOptions(ctx, errors.OpQuery, query, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -255,12 +255,12 @@ func (c *Client) Query(ctx context.Context, db string, query Stmt, options ...Qu
 }
 
 func (c *Client) QueryToJson(ctx context.Context, db string, query Stmt, options ...QueryOption) (string, error) {
-	ctx, cancel, err := c.contextSetup(ctx, false) // Note: cancel is called when *RowIterator has Stop() called.
+	ctx, cancel, err := contextSetup(ctx, false) // Note: cancel is called when *RowIterator has Stop() called.
 	if err != nil {
 		return "", err
 	}
 
-	opts, err := c.setQueryOptions(ctx, errors.OpQuery, query, options...)
+	opts, err := setQueryOptions(ctx, errors.OpQuery, query, options...)
 	if err != nil {
 		return "", err
 	}
@@ -289,12 +289,12 @@ func (c *Client) Mgmt(ctx context.Context, db string, query Stmt, options ...Mgm
 		return nil, errors.ES(errors.OpMgmt, errors.KClientArgs, "a Mgmt() call cannot accept a Stmt object that has Definitions or Parameters attached")
 	}
 
-	ctx, cancel, err := c.contextSetup(ctx, true) // Note: cancel is called when *RowIterator has Stop() called.
+	ctx, cancel, err := contextSetup(ctx, true) // Note: cancel is called when *RowIterator has Stop() called.
 	if err != nil {
 		return nil, err
 	}
 
-	opts, err := c.setMgmtOptions(ctx, errors.OpMgmt, query, options...)
+	opts, err := setMgmtOptions(ctx, errors.OpMgmt, query, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +326,7 @@ func (c *Client) Mgmt(ctx context.Context, db string, query Stmt, options ...Mgm
 	return iter, nil
 }
 
-func (*Client) setQueryOptions(ctx context.Context, op errors.Op, query Stmt, options ...QueryOption) (*queryOptions, error) {
+func setQueryOptions(ctx context.Context, op errors.Op, query Stmt, options ...QueryOption) (*queryOptions, error) {
 	params, err := query.params.toParameters(query.defs)
 	if err != nil {
 		return nil, errors.ES(op, errors.KClientArgs, "QueryValues in the the Stmt were incorrect: %s", err).SetNoRetry()
@@ -361,7 +361,7 @@ func (*Client) setQueryOptions(ctx context.Context, op errors.Op, query Stmt, op
 	return opt, nil
 }
 
-func (*Client) setMgmtOptions(ctx context.Context, op errors.Op, query Stmt, options ...MgmtOption) (*mgmtOptions, error) {
+func setMgmtOptions(ctx context.Context, op errors.Op, query Stmt, options ...MgmtOption) (*mgmtOptions, error) {
 	params, err := query.params.toParameters(query.defs)
 	if err != nil {
 		return nil, errors.ES(op, errors.KClientArgs, "QueryValues in the the Stmt were incorrect: %s", err).SetNoRetry()
@@ -432,7 +432,7 @@ func (c *Client) getConn(callType callType, options connOptions) (queryer, error
 
 var nower = time.Now
 
-func (*Client) contextSetup(ctx context.Context, mgmtCall bool) (context.Context, context.CancelFunc, error) {
+func contextSetup(ctx context.Context, mgmtCall bool) (context.Context, context.CancelFunc, error) {
 	t, ok := ctx.Deadline()
 	if ok {
 		d := t.Sub(nower())


### PR DESCRIPTION
Previously, the query client was locked for every request.

This created a long queue in some workflows.

Turns out this was unneeded by the code.