### PR TITLE
* introduced API for setting client version name

### DIFF
--- a/kusto/conn.go
+++ b/kusto/conn.go
@@ -39,10 +39,11 @@ type conn struct {
 	auth                           Authorization
 	endMgmt, endQuery, streamQuery *url.URL
 	client                         *http.Client
+	versionName                    string
 }
 
 // newConn returns a new conn object with an injected http.Client
-func newConn(endpoint string, auth Authorization, client *http.Client) (*conn, error) {
+func newConn(endpoint string, auth Authorization, client *http.Client, versionName string) (*conn, error) {
 	if !validURL.MatchString(endpoint) {
 		return nil, errors.ES(errors.OpServConn, errors.KClientArgs, "endpoint is not valid(%s), should be https://<cluster name>.*", endpoint).SetNoRetry()
 	}
@@ -58,6 +59,7 @@ func newConn(endpoint string, auth Authorization, client *http.Client) (*conn, e
 		endQuery:    &url.URL{Scheme: "https", Host: u.Host, Path: "/v2/rest/query"},
 		streamQuery: &url.URL{Scheme: "https", Host: u.Host, Path: "/v1/rest/ingest/"},
 		client:      client,
+		versionName: versionName,
 	}
 
 	return c, nil
@@ -142,7 +144,7 @@ func (c *conn) doRequest(ctx context.Context, execType int, db string, query Stm
 	header := http.Header{}
 	header.Add("Accept", "application/json")
 	header.Add("Accept-Encoding", "gzip")
-	header.Add("x-ms-client-version", "Kusto.Go.Client: "+version.Kusto)
+	header.Add("x-ms-client-version", "Kusto.Go.Client: "+version.Kusto+"["+c.versionName+"]")
 	header.Add("Content-Type", "application/json; charset=utf-8")
 	header.Add("x-ms-client-request-id", "KGC.execute;"+uuid.New().String())
 

--- a/kusto/ingest/ingest.go
+++ b/kusto/ingest/ingest.go
@@ -233,7 +233,7 @@ func (i *Ingestion) getStreamConn() (*conn.Conn, error) {
 		return i.streamConn, nil
 	}
 
-	sc, err := conn.New(i.client.Endpoint(), i.client.Auth(), i.client.HttpClient())
+	sc, err := conn.New(i.client.Endpoint(), i.client.Auth(), i.client.HttpClient(), i.client.VersionName())
 	if err != nil {
 		return nil, err
 	}

--- a/kusto/ingest/ingest_test.go
+++ b/kusto/ingest/ingest_test.go
@@ -13,9 +13,10 @@ import (
 )
 
 type mockClient struct {
-	endpoint string
-	auth     kusto.Authorization
-	onMgmt   func(ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
+	endpoint    string
+	versionName string
+	auth        kusto.Authorization
+	onMgmt      func(ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
 }
 
 func (m mockClient) HttpClient() *http.Client {
@@ -36,6 +37,10 @@ func (m mockClient) Endpoint() string {
 
 func (m mockClient) Query(context.Context, string, kusto.Stmt, ...kusto.QueryOption) (*kusto.RowIterator, error) {
 	panic("not implemented")
+}
+
+func (m mockClient) VersionName() string {
+	return m.versionName
 }
 
 func (m mockClient) Mgmt(ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error) {

--- a/kusto/ingest/internal/conn/conn.go
+++ b/kusto/ingest/internal/conn/conn.go
@@ -43,7 +43,7 @@ type Conn struct {
 }
 
 // New returns a new Conn object.
-func New(endpoint string, auth kusto.Authorization, client *http.Client) (*Conn, error) {
+func New(endpoint string, auth kusto.Authorization, client *http.Client, versionName string) (*Conn, error) {
 	if !validURL.MatchString(endpoint) {
 		return nil, errors.ES(
 			errors.OpServConn,
@@ -52,14 +52,14 @@ func New(endpoint string, auth kusto.Authorization, client *http.Client) (*Conn,
 		).SetNoRetry()
 	}
 
-	return newWithoutValidation(endpoint, auth, client)
+	return newWithoutValidation(endpoint, auth, client, versionName)
 }
 
-func newWithoutValidation(endpoint string, auth kusto.Authorization, client *http.Client) (*Conn, error) {
+func newWithoutValidation(endpoint string, auth kusto.Authorization, client *http.Client, versionName string) (*Conn, error) {
 	headers := http.Header{}
 	headers.Add("Accept", "application/json")
 	headers.Add("Accept-Encoding", "gzip,deflate")
-	headers.Add("x-ms-client-version", "Kusto.Go.Client: "+version.Kusto)
+	headers.Add("x-ms-client-version", "Kusto.Go.Client: "+version.Kusto+"["+versionName+"]")
 	headers.Add("Connection", "Keep-Alive")
 
 	// TODO(daniel/jdoak): Get rid of this Replace stuff. I mean, its just hacky.

--- a/kusto/ingest/internal/conn/conn_test.go
+++ b/kusto/ingest/internal/conn/conn_test.go
@@ -165,7 +165,7 @@ func TestStream(t *testing.T) {
 			time.Sleep(10 * time.Millisecond)
 
 			fmt.Println(server.port)
-			conn, err := newWithoutValidation(fmt.Sprintf("http://127.0.0.1:%d", server.port), kusto.Authorization{}, &http.Client{})
+			conn, err := newWithoutValidation(fmt.Sprintf("http://127.0.0.1:%d", server.port), kusto.Authorization{}, &http.Client{}, "test-client")
 			if err != nil {
 				panic(err)
 			}

--- a/kusto/ingest/query_client.go
+++ b/kusto/ingest/query_client.go
@@ -15,4 +15,5 @@ type QueryClient interface {
 	Query(ctx context.Context, db string, query kusto.Stmt, options ...kusto.QueryOption) (*kusto.RowIterator, error)
 	Mgmt(ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
 	HttpClient() *http.Client
+	VersionName() string
 }

--- a/kusto/ingest/streaming.go
+++ b/kusto/ingest/streaming.go
@@ -32,7 +32,7 @@ var FileIsBlobErr = errors.ES(errors.OpIngestStream, errors.KClientArgs, "blobst
 // More information can be found here:
 // https://docs.microsoft.com/en-us/azure/kusto/management/create-ingestion-mapping-command
 func NewStreaming(client QueryClient, db, table string) (*Streaming, error) {
-	streamConn, err := conn.New(client.Endpoint(), client.Auth(), client.HttpClient())
+	streamConn, err := conn.New(client.Endpoint(), client.Auth(), client.HttpClient(), client.VersionName())
 	if err != nil {
 		return nil, err
 	}

--- a/kusto/kcsb.go
+++ b/kusto/kcsb.go
@@ -2,11 +2,12 @@ package kusto
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+
 	kustoErrors "github.com/Azure/azure-kusto-go/kusto/data/errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"strconv"
-	"strings"
 )
 
 type ConnectionStringBuilder struct {
@@ -28,6 +29,7 @@ type ConnectionStringBuilder struct {
 	RedirectURL                      string
 	DefaultAuth                      bool
 	ClientOptions                    *azcore.ClientOptions
+	ClientVersionName                string
 }
 
 // params mapping
@@ -278,6 +280,12 @@ func (kcsb *ConnectionStringBuilder) WithDefaultAzureCredential() *ConnectionStr
 	kcsb.resetConnectionString()
 	kcsb.DefaultAuth = true
 	return kcsb
+}
+
+func (kcsb *ConnectionStringBuilder) SetClientVersionForTracing(clientVersionName string) {
+	if isEmpty(clientVersionName) {
+		kcsb.ClientVersionName = strings.Trim(clientVersionName, " ")
+	}
 }
 
 // Method to be used for generating TokenCredential


### PR DESCRIPTION
#### Pull Request Description

Provided API ConnectionStringBuilder.SetClientVersionForTracing()

client Version Name will be appended to client version header. 

issue ref: #138 
---

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- None
