### PR TITLE
* Close the metadata client as well once we retrieve metadata

### DIFF
--- a/kusto/cloudinfo.go
+++ b/kusto/cloudinfo.go
@@ -3,14 +3,15 @@ package kusto
 import (
 	"encoding/json"
 	"fmt"
-	kustoErrors "github.com/Azure/azure-kusto-go/kusto/data/errors"
-	"github.com/Azure/azure-kusto-go/kusto/utils"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"sync"
 	"time"
+
+	kustoErrors "github.com/Azure/azure-kusto-go/kusto/data/errors"
+	"github.com/Azure/azure-kusto-go/kusto/utils"
 )
 
 // abstraction to query metadata and use this information for providing all
@@ -69,6 +70,7 @@ func GetMetadata(kustoUri string) (CloudInfo, error) {
 		u.Path = metadataPath
 		// TODO should we make this timeout configurable.
 		metadataClient := http.Client{Timeout: time.Duration(5) * time.Second}
+		defer metadataClient.CloseIdleConnections() // close this client once we get the metadata
 		req, err := http.NewRequest("GET", u.String(), nil)
 
 		if err != nil {


### PR DESCRIPTION
Close the metadata client as well once we retrieve metadata

**Fixes:**
- Closes the cloudinfo client once the metadata is retrieved
