### PR TITLE
Unify all http clients

### DIFF
--- a/kusto/cloudinfo_test.go
+++ b/kusto/cloudinfo_test.go
@@ -134,7 +134,7 @@ func TestGetMetadata(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			s.code = test.code
 			s.payload = []byte(test.payload)
-			res, err := GetMetadata(s.urlStr() + "/" + test.name) // Adding test name to the path make sure multiple URL's can be cached
+			res, err := GetMetadata(s.urlStr()+"/"+test.name, &http.Client{}) // Adding test name to the path make sure multiple URL's can be cached
 			if test.err {
 				assert.NotNil(t, err)
 				assert.Equal(t, test.errwant, err.Error())

--- a/kusto/conn.go
+++ b/kusto/conn.go
@@ -184,6 +184,7 @@ func (c *conn) doRequest(ctx context.Context, execType int, db string, query Stm
 	}
 
 	if c.auth.TokenProvider != nil && c.auth.TokenProvider.AuthorizationRequired() {
+		c.auth.TokenProvider.SetHttp(c.client)
 		token, tokenType, tkerr := c.auth.TokenProvider.AcquireToken(ctx)
 		if tkerr != nil {
 			return 0, nil, nil, nil, errors.ES(op, errors.KInternal, "Error while getting token : %s", tkerr)

--- a/kusto/ingest/ingest.go
+++ b/kusto/ingest/ingest.go
@@ -67,7 +67,7 @@ func New(client QueryClient, db, table string, options ...Option) (*Ingestion, e
 		option(i)
 	}
 
-	fs, err := queued.New(db, table, mgr, queued.WithStaticBuffer(i.bufferSize, i.maxBuffers))
+	fs, err := queued.New(db, table, mgr, client.HttpClient(), queued.WithStaticBuffer(i.bufferSize, i.maxBuffers))
 	if err != nil {
 		return nil, err
 	}

--- a/kusto/ingest/internal/conn/conn.go
+++ b/kusto/ingest/internal/conn/conn.go
@@ -128,6 +128,7 @@ func (c *Conn) StreamIngest(ctx context.Context, db, table string, payload io.Re
 	headers.Add("Content-Type", "application/json; charset=utf-8")
 	headers.Add("Content-Encoding", "gzip")
 	if c.auth.TokenProvider != nil && c.auth.TokenProvider.AuthorizationRequired() {
+		c.auth.TokenProvider.SetHttp(c.client)
 		token, tokenType, tkerr := c.auth.TokenProvider.AcquireToken(ctx)
 		if tkerr != nil {
 			return tkerr

--- a/kusto/test/etoe/etoe_test.go
+++ b/kusto/test/etoe/etoe_test.go
@@ -1944,12 +1944,5 @@ func isASCII(s string) bool {
 }
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m, goleak.Cleanup(func(exitCode int) {
-		if exitCode == 0 {
-			// Some of our dependencies (azure queues, auth) have a global http client, which is hardcoded to kill idle connections after x minutes,
-			// so we need to wait for that to happen before we exit.
-			time.Sleep(120 * time.Second)
-		}
-		os.Exit(exitCode)
-	}))
+	goleak.VerifyTestMain(m)
 }


### PR DESCRIPTION
The only way to stop leaks is to be in control of all of the resources.

This PR makes sure the same http client is used in:
* Queries
* Ingestion
* Cloud Info
* Authentication
* Queues
* Blob

Not only this solves our leaks (since we can call CloseIdle on when we close the client),
It also lets the user control everything with the given client, which means we get another parity item - Proxy support, for free!