### PR TITLE
Removed forced check for core.windows.net

### DIFF
--- a/kusto/ingest/internal/resources/resources.go
+++ b/kusto/ingest/internal/resources/resources.go
@@ -46,7 +46,7 @@ type URI struct {
 // parse parses a string representing a Kutso resource URI.
 func parse(uri string) (*URI, error) {
 	// Regex representing URI that is expected:
-	// https://(\w+).(queue|blob|table).core.windows.net/([\w,-]+)\?(.*)
+	// https://(\w+).(queue|blob|table).[\w.]+/([\w,-]+)\?(.*)
 
 	u, err := url.Parse(uri)
 	if err != nil {
@@ -55,10 +55,6 @@ func parse(uri string) (*URI, error) {
 
 	if u.Scheme != "https" {
 		return nil, fmt.Errorf("URI scheme must be 'https', was '%s'", u.Scheme)
-	}
-
-	if !strings.HasSuffix(u.Hostname(), ".core.windows.net") {
-		return nil, fmt.Errorf("URI hostname does not end with '.core.windows.net'")
 	}
 
 	hostSplit := strings.Split(u.Hostname(), ".")

--- a/kusto/ingest/internal/resources/resources.go
+++ b/kusto/ingest/internal/resources/resources.go
@@ -45,8 +45,8 @@ type URI struct {
 
 // parse parses a string representing a Kutso resource URI.
 func parse(uri string) (*URI, error) {
-	// Regex representing URI that is expected:
-	// https://(\w+).(queue|blob|table).[\w.]+/([\w,-]+)\?(.*)
+	// Example for a valid url:
+	// https://fkjsalfdks.blob.core.windows.com/sdsadsadsa?sas=asdasdasd
 
 	u, err := url.Parse(uri)
 	if err != nil {

--- a/kusto/ingest/internal/resources/resources.go
+++ b/kusto/ingest/internal/resources/resources.go
@@ -59,7 +59,7 @@ func parse(uri string) (*URI, error) {
 
 	hostSplit := strings.Split(u.Hostname(), ".")
 	if len(hostSplit) != 5 {
-		return nil, fmt.Errorf("URI(%s) is invalid: had incorrect URL path before '.core.windows.net'", uri)
+		return nil, fmt.Errorf("Storage URI (%s) is invalid'", uri)
 	}
 
 	v := &URI{

--- a/kusto/ingest/internal/resources/resources.go
+++ b/kusto/ingest/internal/resources/resources.go
@@ -58,8 +58,8 @@ func parse(uri string) (*URI, error) {
 	}
 
 	hostSplit := strings.Split(u.Hostname(), ".")
-	if len(hostSplit) != 5 {
-		return nil, fmt.Errorf("Storage URI (%s) is invalid'", uri)
+	if len(hostSplit) < 5 {
+		return nil, fmt.Errorf("error: Storage URI (%s) is invalid'", uri)
 	}
 
 	v := &URI{

--- a/kusto/ingest/internal/resources/resources_test.go
+++ b/kusto/ingest/internal/resources/resources_test.go
@@ -37,11 +37,6 @@ func TestParse(t *testing.T) {
 			err:  true,
 		},
 		{
-			desc: "invalid domain",
-			url:  "https://account.blob.core.invalid.net/objectname",
-			err:  true,
-		},
-		{
 			desc: "no object name provided",
 			url:  "https://account.invalid.core.windows.net/",
 			err:  true,


### PR DESCRIPTION
The long term solution is endpoints validation, but this works for now.