### PR TITLE
 kql tweaks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,5 @@
-#### Pull Request Description
-
-_[Add a description of your pull request here]_
-
----
-
-#### Future Release Comment
-_[Add description of your change, to include in the next release]_
-_[Delete any or all irrelevant sections, e.g. if your change does not warrant a release comment at all]_
-
-**Breaking Changes:**
-- None
-
-**Features:**
-- None
-
-**Fixes:**
-- None
+### Added
+### Changed
+### Fixed
+### Removed
+### Security

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ client, err = kusto.New(kustoConnectionString)
 
 #### Simple queries
 
+* Work for all types of requests, including queries and management commands.
+* Limited to queries that can be built using a string literal known at compile time.
+
 The simplest queries can be built using `kql.New`:
 
 ```go
@@ -127,6 +130,8 @@ Queries can only be built using a string literals known at compile time, and spe
 The reason for this is to discourage the use of string concatenation to build queries, which can lead to security vulnerabilities.
 
 #### Queries with parameters
+
+* Only work for queries.
 
 It is recommended to use parameters for queries that contain user input.  
 Management commands can not use parameters, and therefore should be built using the builder (see next section).
@@ -156,7 +161,9 @@ if err != nil {
 fmt.Println(params.ToDeclarationString()) // declare query_parameters(startTime:datetime, nodeIdValue:int);
 ```
 
-#### Queries with runtime data
+#### Queries with inline parameters
+* Works for queries and management commands.
+* More involved building of queries, but allows for more flexibility.
 
 Queries with runtime data can be built using `kql.New`.
 The builder will only accept the correct types for each part of the query, and will escape any special characters in the data.
@@ -264,14 +271,11 @@ some prerequisite knowledge of acceptable data formats, mapping references, etc.
 
 That documentation can be found [here](https://docs.microsoft.com/en-us/azure/kusto/management/data-ingestion/)
 
-Kusto's ingestion service makes no guarantees on when the data will show up in the table and is optimized for
-large chunks of data and not small uploads at a high rate.
-
 If ingesting data from memory, it is suggested that you stream the data in via `FromReader()` passing in the reader
 from an `io.Pipe()`. The data will not begin ingestion until the writer closes.
 
 
-#### Setup an ingestion client
+#### Creating a queued ingestion client
 
 Setup is quite simple, simply pass a `*kusto.Client`, the name of the database and table you wish to ingest into.
 
@@ -284,7 +288,16 @@ if err != nil {
 defer in.Close()
 ```
 
-#### From a File
+#### Other Ingestion Clients
+
+There are other ingestion clients that can be used for different ingestion scenarios.  The `ingest` package provides
+the following clients:
+* Queued Ingest - `ingest.New()` - the default client, uses queues and batching to ingest data. Most reliable.
+* Streaming Ingest - `ingest.NewStreaming()` - Directly streams data into the engine. Fast, but is limited with size and can fail.
+* Managed Streaming Ingest - `ingest.NewManaged()` - Combines a streaming ingest client with a queued ingest client to provide a reliable ingestion method that is fast and can ingest large amounts of data. 
+ Managed Streaming will try to stream the data, and if it fails multiple times, it will fall back to a queued ingestion.
+
+#### Ingestion From a File
 
 Ingesting a local file requires simply passing the path to the file to be ingested:
 
@@ -297,7 +310,7 @@ if _, err := in.FromFile(ctx, "/path/to/a/local/file"); err != nil {
 `FromFile()` will accept Unix path names on Unix platforms and Windows path names on Windows platforms.
 The file will not be deleted after upload (there is an option that will allow that though).
 
-#### From a Blob Storage File
+#### Ingestion From a Blob Storage File
 
 This package will also accept ingestion from an Azure Blob Storage file:
 
@@ -334,16 +347,6 @@ if _, err := in.FromReader(ctx, r); err != nil {
 
 It is important to remember that `FromReader()` will terminate when it receives an `io.EOF` from the `io.Reader`.  Use `io.Readers` that won't
 return `io.EOF` until the `io.Writer` is closed (such as `io.Pipe`).
-
-#### From a Stream
-
-Ingestion from a stream commits blocks of fully formed data encodes (JSON, AVRO, ...) into Kusto:
-
-```go
-if err := in.Stream(ctx, jsonEncodedData, ingest.JSON, "mappingName"); err != nil {
-	panic("add error handling")
-}
-```
 
 ## Best Practices
 See the SDK [best practices guide](https://docs.microsoft.com/azure/data-explorer/kusto/api/netfx/kusto-ingest-best-practices), which though written for the .NET SDK, applies similarly here.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ The reason for this is to discourage the use of string concatenation to build qu
 
 #### Queries with parameters
 
-* Only work for queries.
+* Can re-use the same query with different parameters.
+* Only work for queries, management commands are not supported.
 
 It is recommended to use parameters for queries that contain user input.  
 Management commands can not use parameters, and therefore should be built using the builder (see next section).
@@ -159,6 +160,10 @@ if err != nil {
 
 // You can see the generated parameters using the ToDeclarationString() method:
 fmt.Println(params.ToDeclarationString()) // declare query_parameters(startTime:datetime, nodeIdValue:int);
+
+// You can then use the same query with different parameters:
+params2 :=  kql.NewParameters().AddDateTime("startTime", dt).AddInt("nodeIdValue", 2)
+results, err = client.Query(ctx, database, query, QueryParameters(params2))
 ```
 
 #### Queries with inline parameters

--- a/kusto/conn.go
+++ b/kusto/conn.go
@@ -88,7 +88,7 @@ func (c *Conn) query(ctx context.Context, db string, query Statement, options *q
 }
 
 // mgmt is used to do management queries to Kusto.
-func (c *Conn) mgmt(ctx context.Context, db string, query Stmt, options *mgmtOptions) (execResp, error) {
+func (c *Conn) mgmt(ctx context.Context, db string, query Statement, options *mgmtOptions) (execResp, error) {
 	return c.execute(ctx, execMgmt, db, query, *options.requestProperties)
 }
 

--- a/kusto/conn_test.go
+++ b/kusto/conn_test.go
@@ -3,6 +3,7 @@ package kusto
 import (
 	"context"
 	"github.com/Azure/azure-kusto-go/kusto/data/errors"
+	"github.com/Azure/azure-kusto-go/kusto/kql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"strings"
@@ -60,7 +61,7 @@ func TestHeaders(t *testing.T) {
 			queryOptions = append(queryOptions, Application(tt.propApplication))
 			queryOptions = append(queryOptions, User(tt.propUser))
 
-			opts, err := setQueryOptions(context.Background(), errors.OpQuery, NewStmt("test"), queryOptions...)
+			opts, err := setQueryOptions(context.Background(), errors.OpQuery, kql.New("test"), queryOptions...)
 			require.NoError(t, err)
 
 			client, err := New(kcsb)

--- a/kusto/doc.go
+++ b/kusto/doc.go
@@ -11,117 +11,191 @@ For details on the Azure Kusto service, see: https://azure.microsoft.com/en-us/s
 
 For general documentation on APIs and the Kusto query language, see: https://docs.microsoft.com/en-us/azure/data-explorer/
 
-# Creating an Authorizer and a Client
+## Examples
 
-To begin using this package, create an Authorizer and a client targeting your Kusto endpoint:
+Examples for various scenarios can be found on [pkg.go.dev](https://pkg.go.dev/github.com/Azure/azure-kusto-go#readme-examples) or in the example*_test.go files in our GitHub repo for [azure-kusto-go](https://github.com/Azure/azure-kusto-go/tree/master/kusto).
 
-	// auth package is: "github.com/Azure/go-autorest/autorest/azure/auth"
+### Create the connection string
 
-	authorizer := kusto.Authorization{
-		Config: auth.NewClientCredentialsConfig(clientID, clientSecret, tenantID),
-	}
+Azure Data Explorer (Kusto) connection strings are created using a connection string builder for an existing Azure Data Explorer (Kusto) cluster endpoint of the form `https://<cluster name>.<location>.kusto.windows.net`.
 
-	client, err := kusto.New(endpoint, authorizer)
+```go
+kustoConnectionStringBuilder := kusto.NewConnectionStringBuilder(endpoint)
+```
+
+### Create and authenticate the client
+
+Azure Data Explorer (Kusto) clients are created from a connection string and authenticated using a credential from the [Azure Identity package][azure_identity_pkg], like [DefaultAzureCredential][default_azure_credential].
+You can also authenticate a client using a system- or user-assigned managed identity with Azure Active Directory (AAD) credentials.
+
+#### Using the `DefaultAzureCredential`
+
+```go
+// kusto package is: github.com/Azure/azure-kusto-go/kusto
+
+// Initialize a new kusto client using the default Azure credential
+kustoConnectionString := kustoConnectionStringBuilder.WithDefaultAzureCredential()
+client, err = kusto.New(kustoConnectionString)
+
 	if err != nil {
 		panic("add error handling")
 	}
 
-For more examples on ways to create an Authorization object, see the Authorization object documentation.
+// Be sure to close the client when you're done. (Error handling omitted for brevity.)
+defer client.Close()
+```
 
-# Querying for Rows
+#### Using the `az cli`
 
-Kusto provides a single method for querying, Query().  Query uses a Stmt object to provides SQL-like injection protection
-and accepts only string constants for arguments.
+```go
+kustoConnectionString := kustoConnectionStringBuilder.WithAzCli()
+client, err = kusto.New(kustoConnectionString)
+```
 
-	// table package is: data/table
+#### Using a system-assigned managed identity
 
-	// Query our database table "systemNodes" for the CollectionTimes and the NodeIds.
-	iter, err := client.Query(ctx, "database", kusto.NewStmt("systemNodes | project CollectionTime, NodeId"))
+```go
+kustoConnectionString := kustoConnectionStringBuilder.WithSystemManagedIdentity()
+client, err = kusto.New(kustoConnectionString)
+```
+
+#### Using a user-assigned managed identity
+
+```go
+kustoConnectionString := kustoConnectionStringBuilder.WithUserManagedIdentity(clientID)
+client, err = kusto.New(kustoConnectionString)
+```
+
+#### Using an application token
+
+```go
+kustoConnectionString := kustoConnectionStringBuilder.WithApplicationToken(appId, appToken)
+client, err = kusto.New(kustoConnectionString)
+```
+
+#### Using an application certificate
+
+```go
+kustoConnectionString := kustoConnectionStringBuilder.WithAppCertificate(appId, certificate, thumbprint, sendCertChain, authorityID)
+client, err = kusto.New(kustoConnectionString)
+```
+
+### Querying
+
+#### Simple queries
+
+The simplest queries can be built using `kql.New`:
+
+```go
+query := kql.New("systemNodes | project CollectionTime, NodeId")
+```
+
+Queries can only be built using a string literals known at compile time, and special methods for specific parts of the query.
+The reason for this is to discourage the use of string concatenation to build queries, which can lead to security vulnerabilities.
+
+#### Queries with parameters
+
+It is recommended to use parameters for queries that contain user input.
+Management commands can not use parameters, and therefore should be built using the builder (see next section).
+
+Parameters can be implicitly referenced in a query:
+
+```go
+query := kql.New("systemNodes | project CollectionTime, NodeId | where CollectionTime > startTime and NodeId == nodeIdValue")
+```
+
+Here, `startTime` and `nodeIdValue` are parameters that can be passed to the query.
+
+To Pass the parameters values to the query, create `kql.Parameters`:
+
+```
+params :=  kql.NewParameters().AddDateTime("startTime", dt).AddInt("nodeIdValue", 1)
+```
+
+And then pass it to the `Query` method, as an option:
+```go
+results, err := client.Query(ctx, database, query, QueryParameters(params))
+
+	if err != nil {
+	    panic("add error handling")
+	}
+
+// You can see the generated parameters using the ToDeclarationString() method:
+fmt.Println(params.ToDeclarationString()) // declare query_parameters(startTime:datetime, nodeIdValue:int);
+```
+
+#### Queries with runtime data
+
+Queries with runtime data can be built using `kql.New`.
+The builder will only accept the correct types for each part of the query, and will escape any special characters in the data.
+
+For example, here is a query that dynamically accepts values for the table name, and the comparison parameters for the columns:
+
+```go
+dt, _ := time.Parse(time.RFC3339Nano, "2020-03-04T14:05:01.3109965Z")
+tableName := "system nodes"
+value := 1
+
+query := kql.New("")
+
+	.AddTable(tableName)
+	.AddLiteral(" | where CollectionTime == ").AddDateTime(dt)
+	.AddLiteral(" and ")
+	.AddLiteral("NodeId == ").AddInt(value)
+
+// To view the query string, use the String() method:
+fmt.Println(query.String())
+// Output: ['system nodes'] | where CollectionTime == datetime(2020-03-04T14:05:01.3109965Z) and NodeId == int(1)
+```
+
+Building queries like this is useful for queries that are built from user input, or for queries that are built from a template, and are valid for management commands too.
+
+#### Query For Rows
+
+The kusto `table` package queries data into a ***table.Row** which can be printed or have the column data extracted.
+
+```go
+// table package is: github.com/Azure/azure-kusto-go/kusto/data/table
+
+// Query our database table "systemNodes" for the CollectionTimes and the NodeIds.
+iter, err := client.Query(ctx, "database", query)
+
 	if err != nil {
 		panic("add error handling")
 	}
-	defer iter.Stop()
 
-	// .Do() will call the function for every row in the table.
-	err = iter.Do(
-		func(row *table.Row) error {
-			if row.Replace {
-				fmt.Println("---") // Replace flag indicates that the query result should be cleared and replaced with this row
-			}
-			fmt.Println(row) // As a convenience, printing a *table.Row will output csv
-			return nil
+defer iter.Stop()
+
+// .Do() will call the function for every row in the table.
+err = iter.DoOnRowOrError(
+
+	    func(row *table.Row, e *kustoErrors.Error) error {
+	        if e != nil {
+	            return e
+	        }
+	        if row.Replace {
+	            fmt.Println("---") // Replace flag indicates that the query result should be cleared and replaced with this row
+	        }
+	        fmt.Println(row) // As a convenience, printing a *table.Row will output csv
+	        return nil
 		},
-	)
+
+)
+
 	if err != nil {
 		panic("add error handling")
 	}
 
-# Querying with parameters
+```
 
-Users will sometimes want to use query parameters (Read more here - https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/queryparametersstatement?pivots=azuredataexplorer).
-In this case, the StatementBuilder and QueryParameters structs should be used.
+#### Query Into Structs
 
-	dt, _ := time.Parse(time.RFC3339Nano, "2020-03-04T14:05:01.3109965Z")
-	// Query our database table "systemNodes" for the CollectionTimes and the NodeIds.
-	statement := kql.NewStatementBuilder("systemNodes | where CollectionTime == time and NodeId == id")
-	params :=  kql.NewStatementQueryParameters().AddDateTime("time", dt).AddInt("id", 1)
-	iter, err := client.Query(ctx, "database", statement, params)
-	fmt.Println(fmt.Sprintf("%s\n%s", params.ToDeclarationString(), statement.String()))
-	// Will print:
-	// declare query_parameters(time:datetime, id:int);
-	// systemNodes | where CollectionTime == time and NodeId == id
-	if err != nil {
-		panic("add error handling")
-	}
-	defer iter.Stop()
+Users will often want to turn the returned data into Go structs that are easier to work with.  The ***table.Row** object
+that is returned supports this via the `.ToStruct()` method.
 
-	// .Do() will call the function for every row in the table.
-	err = iter.Do(
-		func(row *table.Row) error {
-			if row.Replace {
-				fmt.Println("---") // Replace flag indicates that the query result should be cleared and replaced with this row
-			}
-			fmt.Println(row) // As a convenience, printing a *table.Row will output csv
-			return nil
-		},
-	)
-	if err != nil {
-		panic("add error handling")
-	}
+```go
+// NodeRec represents our Kusto data that will be returned.
 
-# Querying with StatementBuilder
-Another way to build your query is using the StatementBuilder struct. With this struct you build your query as a combination of literals and special entities.
-This is mostly applicable when your KQL commands which do not support query parameters, or for situations where Kusto entities like database, table, column or function need to be safely added from variables.
-
-	dt, _ := time.Parse(time.RFC3339Nano, "2020-03-04T14:05:01.3109965Z")
-	tableName := "systemNodes"
-	value := 1
-	// Query our database table "systemNodes" for the CollectionTimes and the NodeIds.
-	iter, err := client.Query(ctx, "database", kql.NewStatementBuilder("").AddTable(tableName).AddLiteral(" | where ").AddColumn("CollectionTime").AddLiteral(" == ").AddDateTime(dt).AddLiteral(" and ").AddColumn("NodeId").AddLiteral(" == ").AddInt(value),
-	if err != nil {
-		panic("add error handling")
-	}
-	defer iter.Stop()
-
-	// .Do() will call the function for every row in the table.
-	err = iter.Do(
-		func(row *table.Row) error {
-			if row.Replace {
-				fmt.Println("---") // Replace flag indicates that the query result should be cleared and replaced with this row
-			}
-			fmt.Println(row) // As a convenience, printing a *table.Row will output csv
-			return nil
-		},
-	)
-	if err != nil {
-		panic("add error handling")
-	}
-
-# Querying Rows Into Structs
-
-Keeping our query the same, instead of printing the Rows we will simply put them into a slice of structs
-
-	// NodeRec represents our Kusto data that will be returned.
 	type NodeRec struct {
 		// ID is the table's NodeId. We use the field tag here to to instruct our client to convert NodeId to ID.
 		ID int64 `kusto:"NodeId"`
@@ -129,98 +203,136 @@ Keeping our query the same, instead of printing the Rows we will simply put them
 		CollectionTime time.Time
 	}
 
-	iter, err := client.Query(ctx, "database", kusto.NewStmt("systemNodes | project CollectionTime, NodeId"))
+iter, err := client.Query(ctx, "database", query)
+
 	if err != nil {
 		panic("add error handling")
 	}
-	defer iter.Stop()
 
-	recs := []NodeRec{}
-	err = iter.Do(
-		func(row *table.Row) error {
+defer iter.Stop()
+
+recs := []NodeRec{}
+err = iter.DoOnRowOrError(
+
+	    func(row *table.Row, e *kustoErrors.Error) error {
+	        if e != nil {
+	        return e
+	        }
 			rec := NodeRec{}
 			if err := row.ToStruct(&rec); err != nil {
 				return err
 			}
 			if row.Replace {
-				recs = recs[:0]  // Replace flag indicates that the query result should be cleared and replaced with this row
+				recs = recs[:0] // Replace flag indicates that the query result should be cleared and replaced with this row
 			}
 			recs = append(recs, rec)
 			return nil
 		},
-	)
+
+)
+
 	if err != nil {
 		panic("add error handling")
 	}
 
-A struct object can use fields to store the Kusto values as normal Go values, pointers to Go values and as value.Kusto types.
-The value.Kusto types are useful when you need to distiguish between the zero value of a variable and the value not being
-set in Kusto.
+```
 
-All value.Kusto types have a .Value and .Valid field. .Value is the native Go value, .Valid is a bool which
-indicates if the value was set. More information can be found in the sub-package data/value.
+### Ingestion
 
-The following is a conversion table from the Kusto column types to native Go values within a struct that are allowed:
+The `ingest` package provides access to Kusto's ingestion service for importing data into Kusto. This requires
+some prerequisite knowledge of acceptable data formats, mapping references, etc.
 
-	From Kusto Type			To Go Kusto Type
-	==============================================================================
-	bool				value.Bool, bool, *bool
-	------------------------------------------------------------------------------
-	datetime			value.DateTime, time.Time, *time.Time
-	------------------------------------------------------------------------------
-	dynamic				value.Dynamic, string, *string
-	------------------------------------------------------------------------------
-	guid				value.GUID, uuid.UUID, *uuid.UUID
-	------------------------------------------------------------------------------
-	int				value.Int, int32, *int32
-	------------------------------------------------------------------------------
-	long				value.Long, int64, *int64
-	------------------------------------------------------------------------------
-	real				value.Real, float64, *float64
-	------------------------------------------------------------------------------
-	string				value.String, string, *string
-	------------------------------------------------------------------------------
-	timestamp			value.Timestamp, time.Duration, *time.Duration
-	------------------------------------------------------------------------------
-	decimal				value.Decimal, string, *string
-	==============================================================================
+That documentation can be found [here](https://docs.microsoft.com/en-us/azure/kusto/management/data-ingestion/)
 
-For more information on Kusto scalar types, see: https://docs.microsoft.com/en-us/azure/kusto/query/scalar-data-types/
+Kusto's ingestion service makes no guarantees on when the data will show up in the table and is optimized for
+large chunks of data and not small uploads at a high rate.
 
-# Stmt
+If ingesting data from memory, it is suggested that you stream the data in via `FromReader()` passing in the reader
+from an `io.Pipe()`. The data will not begin ingestion until the writer closes.
 
-Every query is done using a Stmt. A Stmt is built with Go string constants and can do variable substitution
-using Kusto's Query Paramaters.
+#### Setup an ingestion client
 
-	// rootStmt builds a query that will gather all nodes in the DB.
-	rootStmt := kusto.NewStmt("systemNodes | project CollectionTime, NodeId")
+Setup is quite simple, simply pass a `*kusto.Client`, the name of the database and table you wish to ingest into.
 
-	// singleNodeStmt creates a new Stmt based on rootStmt and adds a "where" clause to find a single node.
-	// We pass a definition that sets the word ParamNodeId to a variable that will be substituted for a
-	// Kusto Long type (which is a a Go int64).
-	singleNodeStmt := rootStmt.Add(" | where NodeId == ParamNodeId").MustDefinitions(
-		kusto.NewDefinitions().Must(
-			kusto.ParamTypes{
-				"ParamNodeId": kusto.ParamType{Type: types.Long},
-			},
-		),
-	)
+```go
+in, err := ingest.New(kustoClient, "database", "table")
 
-	// Query using our singleNodeStmt, variable substituting for ParamNodeId
-	iter, err := client.Query(
-		ctx,
-		"database",
-		singleNode.MustParameters(
-			kusto.NewParameters().Must(
-				kusto.QueryValues{"ParamNodeId": int64(100)},
-			),
-		),
-	)
+	if err != nil {
+		panic("add error handling")
+	}
 
-# Ingest
+// Be sure to close the ingestor when you're done. (Error handling omitted for brevity.)
+defer in.Close()
+```
 
-Support for Kusto ingestion from local files, Azure Blob Storage and streaming is supported in the sub-package ingest.
-See documentation in that package for more details
+#### From a File
+
+Ingesting a local file requires simply passing the path to the file to be ingested:
+
+```go
+
+	if _, err := in.FromFile(ctx, "/path/to/a/local/file"); err != nil {
+		panic("add error handling")
+	}
+
+```
+
+`FromFile()` will accept Unix path names on Unix platforms and Windows path names on Windows platforms.
+The file will not be deleted after upload (there is an option that will allow that though).
+
+#### From a Blob Storage File
+
+This package will also accept ingestion from an Azure Blob Storage file:
+
+```go
+
+	if _, err := in.FromFile(ctx, "https://myaccount.blob.core.windows.net/$root/myblob"); err != nil {
+		panic("add error handling")
+	}
+
+```
+
+This will ingest a file from Azure Blob Storage. We only support `https://` paths and your domain name may differ than what is here.
+
+#### Ingestion from an io.Reader
+
+Sometimes you want to ingest a stream of data that you have in memory without writing to disk.  You can do this simply by chunking the
+data via an `io.Reader`.
+
+```go
+r, w := io.Pipe()
+
+enc := json.NewEncoder(w)
+
+	go func() {
+		defer w.Close()
+		for _, data := range dataSet {
+			if err := enc.Encode(data); err != nil {
+				panic("add error handling")
+			}
+		}
+	}()
+
+	if _, err := in.FromReader(ctx, r); err != nil {
+		panic("add error handling")
+	}
+
+```
+
+It is important to remember that `FromReader()` will terminate when it receives an `io.EOF` from the `io.Reader`.  Use `io.Readers` that won't
+return `io.EOF` until the `io.Writer` is closed (such as `io.Pipe`).
+
+#### From a Stream
+
+Ingestion from a stream commits blocks of fully formed data encodes (JSON, AVRO, ...) into Kusto:
+
+```go
+
+	if err := in.Stream(ctx, jsonEncodedData, ingest.JSON, "mappingName"); err != nil {
+		panic("add error handling")
+	}
+
+```
 
 # Mocking
 

--- a/kusto/doc.go
+++ b/kusto/doc.go
@@ -98,7 +98,8 @@ The reason for this is to discourage the use of string concatenation to build qu
 
 #### Queries with parameters
 
-* Only works for queries, management commands aren't supported.
+* Can re-use the same query with different parameters.
+* Only work for queries, management commands are not supported.
 
 It is recommended to use parameters for queries that contain user input.
 Management commands can not use parameters, and therefore should be built using the builder (see next section).

--- a/kusto/ingest/ingest_test.go
+++ b/kusto/ingest/ingest_test.go
@@ -15,7 +15,7 @@ import (
 type mockClient struct {
 	endpoint string
 	auth     kusto.Authorization
-	onMgmt   func(ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
+	onMgmt   func(ctx context.Context, db string, query kusto.Statement, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
 }
 
 func (m mockClient) ClientDetails() *kusto.ClientDetails {
@@ -41,7 +41,7 @@ func (m mockClient) Query(context.Context, string, kusto.Statement, ...kusto.Que
 	panic("not implemented")
 }
 
-func (m mockClient) Mgmt(ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error) {
+func (m mockClient) Mgmt(ctx context.Context, db string, query kusto.Statement, options ...kusto.MgmtOption) (*kusto.RowIterator, error) {
 	if m.onMgmt != nil {
 		rows, err := m.onMgmt(ctx, db, query, options...)
 		if err != nil || rows != nil {

--- a/kusto/ingest/internal/resources/resources.go
+++ b/kusto/ingest/internal/resources/resources.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Azure/azure-kusto-go/kusto/kql"
 	"net/url"
 	"strings"
 	"sync"
@@ -27,7 +28,7 @@ const (
 
 // mgmter is a private interface that allows us to write hermetic tests against the kusto.Client.Mgmt() method.
 type mgmter interface {
-	Mgmt(ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
+	Mgmt(ctx context.Context, db string, query kusto.Statement, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
 }
 
 var objectTypes = map[string]bool{
@@ -201,7 +202,7 @@ func (m *Manager) AuthContext(ctx context.Context) (string, error) {
 	retryCtx := backoff.WithContext(InitBackoff(), ctx)
 	err := backoff.Retry(func() error {
 		var err error
-		rows, err = m.client.Mgmt(ctx, "NetDefaultDB", kusto.NewStmt(".get kusto identity token"), kusto.IngestionEndpoint())
+		rows, err = m.client.Mgmt(ctx, "NetDefaultDB", kql.New(".get kusto identity token"), kusto.IngestionEndpoint())
 		if err == nil {
 			return nil
 		}
@@ -289,7 +290,7 @@ func (m *Manager) fetch(ctx context.Context) error {
 	retryCtx := backoff.WithContext(InitBackoff(), ctx)
 	err := backoff.Retry(func() error {
 		var err error
-		rows, err = m.client.Mgmt(ctx, "NetDefaultDB", kusto.NewStmt(".get ingestion resources"), kusto.IngestionEndpoint())
+		rows, err = m.client.Mgmt(ctx, "NetDefaultDB", kql.New(".get ingestion resources"), kusto.IngestionEndpoint())
 		if err == nil {
 			return nil
 		}

--- a/kusto/ingest/internal/resources/test_helpers.go
+++ b/kusto/ingest/internal/resources/test_helpers.go
@@ -70,7 +70,7 @@ func (f *FakeMgmt) SetMgmtErr() *FakeMgmt {
 	return f
 }
 
-func (f *FakeMgmt) Mgmt(_ context.Context, db string, query kusto.Stmt, _ ...kusto.MgmtOption) (*kusto.RowIterator, error) {
+func (f *FakeMgmt) Mgmt(_ context.Context, db string, query kusto.Statement, _ ...kusto.MgmtOption) (*kusto.RowIterator, error) {
 	if f.DBEqual != "" {
 		if db != f.DBEqual {
 			panic(fmt.Sprintf("expected db to be %q, was %q", f.DBEqual, db))

--- a/kusto/ingest/managed_test.go
+++ b/kusto/ingest/managed_test.go
@@ -21,9 +21,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type testMgmtFunc func(t *testing.T, ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
+type testMgmtFunc func(t *testing.T, ctx context.Context, db string, query kusto.Statement, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
 
-func failIfQueuedCalled(t *testing.T, _ context.Context, _ string, query kusto.Stmt, _ ...kusto.MgmtOption) (*kusto.RowIterator, error) {
+func failIfQueuedCalled(t *testing.T, _ context.Context, _ string, query kusto.Statement, _ ...kusto.MgmtOption) (*kusto.RowIterator, error) {
 	// .get ingestion resources is always called in the ctor
 	if query.String() == ".get ingestion resources" {
 		return nil, nil
@@ -233,7 +233,7 @@ func TestManaged(t *testing.T) {
 				assert.NoError(t, err)
 				return errors.E(errors.OpIngestStream, errors.KHTTPError, fmt.Errorf("error"))
 			},
-			onMgmt: func(t *testing.T, ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error) {
+			onMgmt: func(t *testing.T, ctx context.Context, db string, query kusto.Statement, options ...kusto.MgmtOption) (*kusto.RowIterator, error) {
 				// .get ingestion resources is always called in the ctor
 				if query.String() == ".get ingestion resources" {
 					return resources.SuccessfulFakeResources().Mgmt(ctx, db, query, options...)
@@ -266,7 +266,7 @@ func TestManaged(t *testing.T) {
 				require.Fail(t, "Big file shouldn't try to stream")
 				return errors.E(errors.OpIngestStream, errors.KHTTPError, fmt.Errorf("error"))
 			},
-			onMgmt: func(t *testing.T, ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error) {
+			onMgmt: func(t *testing.T, ctx context.Context, db string, query kusto.Statement, options ...kusto.MgmtOption) (*kusto.RowIterator, error) {
 				// .get ingestion resources is always called in the ctor
 				if query.String() == ".get ingestion resources" {
 					return resources.SuccessfulFakeResources().Mgmt(ctx, db, query, options...)
@@ -299,7 +299,7 @@ func TestManaged(t *testing.T) {
 				require.Fail(t, "Big file shouldn't try to stream")
 				return errors.E(errors.OpIngestStream, errors.KHTTPError, fmt.Errorf("error"))
 			},
-			onMgmt: func(t *testing.T, ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error) {
+			onMgmt: func(t *testing.T, ctx context.Context, db string, query kusto.Statement, options ...kusto.MgmtOption) (*kusto.RowIterator, error) {
 				// .get ingestion resources is always called in the ctor
 				if query.String() == ".get ingestion resources" {
 					return resources.SuccessfulFakeResources().Mgmt(ctx, db, query, options...)
@@ -335,7 +335,7 @@ func TestManaged(t *testing.T) {
 			mockClient := mockClient{
 				endpoint: "https://test.kusto.windows.net",
 				auth:     kusto.Authorization{},
-				onMgmt: func(ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error) {
+				onMgmt: func(ctx context.Context, db string, query kusto.Statement, options ...kusto.MgmtOption) (*kusto.RowIterator, error) {
 					if test.onMgmt == nil {
 						return nil, nil
 					}

--- a/kusto/ingest/query_client.go
+++ b/kusto/ingest/query_client.go
@@ -13,7 +13,7 @@ type QueryClient interface {
 	Auth() kusto.Authorization
 	Endpoint() string
 	Query(ctx context.Context, db string, query kusto.Statement, options ...kusto.QueryOption) (*kusto.RowIterator, error)
-	Mgmt(ctx context.Context, db string, query kusto.Stmt, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
+	Mgmt(ctx context.Context, db string, query kusto.Statement, options ...kusto.MgmtOption) (*kusto.RowIterator, error)
 	HttpClient() *http.Client
 	ClientDetails() *kusto.ClientDetails
 }

--- a/kusto/kql/builder.go
+++ b/kusto/kql/builder.go
@@ -24,10 +24,14 @@ type Builder struct {
 	builder strings.Builder
 }
 
-func NewBuilder(value stringConstant) *Builder {
+func New(value stringConstant) *Builder {
 	return (&Builder{
 		builder: strings.Builder{},
 	}).AddLiteral(value)
+}
+
+func FromBuilder(builder *Builder) *Builder {
+	return New(stringConstant(builder.String()))
 }
 
 // String implements fmt.Stringer.
@@ -39,10 +43,10 @@ func (b *Builder) addBase(value fmt.Stringer) *Builder {
 	return b
 }
 
-// addUnsafe enables unsafe actions on a Builder - adds a string as is, no validation checking or escaping.
+// AddUnsafe enables unsafe actions on a Builder - adds a string as is, no validation checking or escaping.
 // This turns off safety features that could allow a service client to compromise your data store.
 // USE AT YOUR OWN RISK!
-func (b *Builder) addUnsafe(value string) *Builder {
+func (b *Builder) AddUnsafe(value string) *Builder {
 	b.builder.WriteString(value)
 	return b
 }

--- a/kusto/kql/builder_test.go
+++ b/kusto/kql/builder_test.go
@@ -16,85 +16,85 @@ func TestBuilder(t *testing.T) {
 	}{
 		{
 			"Test empty",
-			NewBuilder(""),
+			New(""),
 			""},
 		{
 			"Test simple literal",
-			NewBuilder("").AddLiteral("foo"),
+			New("").AddLiteral("foo"),
 			"foo"},
 		{
 			"Test simple literal ctor",
-			NewBuilder("foo"),
+			New("foo"),
 			"foo"},
 		{
 			"Test add literal",
-			NewBuilder("foo").AddLiteral("bar"),
+			New("foo").AddLiteral("bar"),
 			"foobar"},
 		{
 			"Test add int",
-			NewBuilder("MyTable | where i != ").AddInt(32),
+			New("MyTable | where i != ").AddInt(32),
 			"MyTable | where i != int(32)",
 		},
 		{
 			"Test add long",
-			NewBuilder("MyTable | where i != ").AddLong(32),
+			New("MyTable | where i != ").AddLong(32),
 			"MyTable | where i != long(32)",
 		},
 		{
 			"Test add real",
-			NewBuilder("MyTable | where i != ").AddReal(32.5),
+			New("MyTable | where i != ").AddReal(32.5),
 			"MyTable | where i != real(32.5)",
 		},
 		{
 			"Test add bool",
-			NewBuilder("MyTable | where i != ").AddBool(true),
+			New("MyTable | where i != ").AddBool(true),
 			"MyTable | where i != bool(true)",
 		},
 		{
 			"Test add datetime",
-			NewBuilder(
+			New(
 				"MyTable | where i != ",
 			).AddDateTime(time.Date(2019, 1, 2, 3, 4, 5, 600, time.UTC)),
 			"MyTable | where i != datetime(2019-01-02T03:04:05.0000006Z)",
 		},
 		{
 			"Test add duration",
-			NewBuilder(
+			New(
 				"MyTable | where i != ",
 			).AddTimespan(1*time.Hour + 2*time.Minute + 3*time.Second + 4*time.Microsecond),
 			"MyTable | where i != timespan(01:02:03.0000040)",
 		},
 		{
 			"Test add duration with days",
-			NewBuilder(
+			New(
 				"MyTable | where i != ",
 			).AddTimespan(49*time.Hour + 2*time.Minute + 3*time.Second + 4*time.Microsecond),
 			"MyTable | where i != timespan(2.01:02:03.0000040)",
 		},
 		{
 			"Test add dynamic",
-			NewBuilder(
+			New(
 				"MyTable | where i != ",
 			).AddDynamic(`{"a": 3, "b": 5.4}`),
 			`MyTable | where i != dynamic({"a": 3, "b": 5.4})`,
 		},
 		{
 			"Test add guid",
-			NewBuilder(
+			New(
 				"MyTable | where i != ",
 			).AddGUID(uuid.MustParse("12345678-1234-1234-1234-123456789012")),
 			"MyTable | where i != guid(12345678-1234-1234-1234-123456789012)",
 		},
 		{
 			"Test add string simple",
-			NewBuilder(
+			New(
 				"MyTable | where i != ",
 			).AddString("foo"),
 			"MyTable | where i != \"foo\"",
 		},
 		{
 			"Test add string with quote",
-			NewBuilder(
+			New(
 				"MyTable | where i != ",
 			).AddString("foo\"bar"),
 			"MyTable | where i != \"foo\\\"bar\"",
@@ -108,7 +108,7 @@ func TestBuilder(t *testing.T) {
 		},
 		{
 			"Test add identifiers",
-			NewBuilder("").
+			New("").
 				AddDatabase("foo_1").AddLiteral(".").
 				AddTable("_bar").AddLiteral(" | where ").
 				AddColumn("_baz").AddLiteral(" == ").
@@ -116,7 +116,7 @@ func TestBuilder(t *testing.T) {
 			`database("foo_1")._bar | where _baz == func_()`},
 		{
 			"Test add identifiers complex",
-			NewBuilder("").
+			New("").
 				AddDatabase("f\"\"o").AddLiteral(".").
 				AddTable("b\\a\\r").AddLiteral(" | where ").
 				AddColumn("b\na\nz").AddLiteral(" == ").

--- a/kusto/kql/builder_test.go
+++ b/kusto/kql/builder_test.go
@@ -101,7 +101,7 @@ func TestBuilder(t *testing.T) {
 		},
 		{
 			"Test add keyword",
-			NewBuilder(
+			New(
 				"MyTable | where i != ",
 			).AddLiteral("(").AddKeyword("key").AddLiteral(")"),
 			"MyTable | where i != (key)",

--- a/kusto/kql/query_parameters.go
+++ b/kusto/kql/query_parameters.go
@@ -67,8 +67,6 @@ func (q *Parameters) AddDecimal(key string, value decimal.Decimal) *Parameters {
 	return q.addBase(key, newValue(value, types.Decimal))
 }
 
-// note - due to the psuedo-random nature of maps, the declaration string might be ordered differently for different runs.
-// might crash the test in those times.
 func (q *Parameters) ToDeclarationString() string {
 	const (
 		declare   = "declare query_parameters("

--- a/kusto/kql/query_parameters_test.go
+++ b/kusto/kql/query_parameters_test.go
@@ -24,13 +24,13 @@ func TestQueryParameters(t *testing.T) {
 	}{
 		{
 			"Test empty",
-			NewBuilder(""),
+			New(""),
 			NewParameters(),
 			[]string{"\n"},
 			map[string]string{}},
 		{
 			"Test single add",
-			NewBuilder(""),
+			New(""),
 			NewParameters().
 				AddString("foo", "bar"),
 			[]string{"declare",
@@ -40,7 +40,7 @@ func TestQueryParameters(t *testing.T) {
 			map[string]string{"foo": "\"bar\""}},
 		{
 			"Test standard",
-			NewBuilder("database(databaseName).table(tableName) | where column == txt ;"),
+			New("database(databaseName).table(tableName) | where column == txt ;"),
 			NewParameters().
 				AddString("databaseName", "foo_1").
 				AddString("tableName", "_bar").
@@ -58,7 +58,7 @@ func TestQueryParameters(t *testing.T) {
 			}},
 		{
 			"Test complex",
-			NewBuilder("where vnum == num and vdec == dec and vdate == dt and vspan == span and tostring(vobj) == tostring(obj) and vb == b and vreal == rl and vstr == str and vlong == lg and vguid == guid"),
+			New("where vnum == num and vdec == dec and vdate == dt and vspan == span and tostring(vobj) == tostring(obj) and vb == b and vreal == rl and vstr == str and vlong == lg and vguid == guid"),
 			NewParameters().
 				AddString("foo", "bar").
 				AddInt("num", 1).
@@ -98,7 +98,7 @@ func TestQueryParameters(t *testing.T) {
 			}},
 		{
 			"Test unusual values",
-			NewBuilder("database(databaseName).table(tableName) | where column == txt ;"),
+			New("database(databaseName).table(tableName) | where column == txt ;"),
 			NewParameters().
 				AddString("databaseName", "f\"\"o").
 				AddString("tableName", "b\a\r").

--- a/kusto/kusto.go
+++ b/kusto/kusto.go
@@ -296,13 +296,10 @@ func setQueryOptions(ctx context.Context, op errors.Op, query Statement, options
 }
 
 func setMgmtOptions(ctx context.Context, op errors.Op, query Statement, options ...MgmtOption) (*mgmtOptions, error) {
-	var params map[string]string
 	if stmt, ok := query.(Stmt); ok {
-		paramsTemp, err := stmt.params.toParameters(stmt.defs)
-		if err != nil {
-			return nil, errors.ES(op, errors.KClientArgs, "QueryValues in the the Stmt were incorrect: %s", err).SetNoRetry()
+		if !stmt.params.IsZero() {
+			return nil, errors.ES(op, errors.KClientArgs, "Parameters aren't compatible with management queries").SetNoRetry()
 		}
-		params = paramsTemp
 	}
 
 	// Match our server deadline to our context.Deadline. This should be set from withing kusto.Query() to always have a value.
@@ -316,8 +313,7 @@ func setMgmtOptions(ctx context.Context, op errors.Op, query Statement, options 
 
 	opt := &mgmtOptions{
 		requestProperties: &requestProperties{
-			Options:    map[string]interface{}{},
-			Parameters: params,
+			Options: map[string]interface{}{},
 		},
 	}
 	if op == errors.OpQuery {

--- a/kusto/kusto.go
+++ b/kusto/kusto.go
@@ -18,7 +18,7 @@ import (
 type queryer interface {
 	io.Closer
 	query(ctx context.Context, db string, query Statement, options *queryOptions) (execResp, error)
-	mgmt(ctx context.Context, db string, query Stmt, options *mgmtOptions) (execResp, error)
+	mgmt(ctx context.Context, db string, query Statement, options *mgmtOptions) (execResp, error)
 	queryToJson(ctx context.Context, db string, query Statement, options *queryOptions) (string, error)
 }
 
@@ -210,10 +210,11 @@ func (c *Client) QueryToJson(ctx context.Context, db string, query Statement, op
 // Mgmt accepts a Stmt, but that Stmt cannot have any query parameters attached at this time.
 // Note that the server has a timeout of 10 minutes for a management call by default unless the context deadline is set.
 // There is a maximum of 1 hour.
-func (c *Client) Mgmt(ctx context.Context, db string, query Stmt, options ...MgmtOption) (*RowIterator, error) {
-
-	if !query.params.IsZero() || !query.defs.IsZero() {
-		return nil, errors.ES(errors.OpMgmt, errors.KClientArgs, "a Mgmt() call cannot accept a Stmt object that has Definitions or Parameters attached")
+func (c *Client) Mgmt(ctx context.Context, db string, query Statement, options ...MgmtOption) (*RowIterator, error) {
+	if stmt, ok := query.(Stmt); ok {
+		if !stmt.params.IsZero() || !stmt.defs.IsZero() {
+			return nil, errors.ES(errors.OpMgmt, errors.KClientArgs, "a Mgmt() call cannot accept a Stmt object that has Definitions or Parameters attached")
+		}
 	}
 
 	ctx, cancel, err := contextSetup(ctx, true) // Note: cancel is called when *RowIterator has Stop() called.
@@ -282,7 +283,7 @@ func setQueryOptions(ctx context.Context, op errors.Op, query Statement, options
 	}
 	if query.SupportsInlineParameters() {
 		if opt.requestProperties.QueryParameters.Count() != 0 {
-			return nil, errors.ES(op, errors.KClientArgs, "kusto.Stmt does not support the QueryParameters option. Construct your query using kql.Builder").SetNoRetry()
+			return nil, errors.ES(op, errors.KClientArgs, "kusto.Stmt does not support the QueryParameters option. Construct your query using `kql.New`").SetNoRetry()
 		}
 		params, err := query.GetParameters()
 		if err != nil {
@@ -294,10 +295,14 @@ func setQueryOptions(ctx context.Context, op errors.Op, query Statement, options
 	return opt, nil
 }
 
-func setMgmtOptions(ctx context.Context, op errors.Op, query Stmt, options ...MgmtOption) (*mgmtOptions, error) {
-	params, err := query.params.toParameters(query.defs)
-	if err != nil {
-		return nil, errors.ES(op, errors.KClientArgs, "QueryValues in the the Stmt were incorrect: %s", err).SetNoRetry()
+func setMgmtOptions(ctx context.Context, op errors.Op, query Statement, options ...MgmtOption) (*mgmtOptions, error) {
+	var params map[string]string
+	if stmt, ok := query.(Stmt); ok {
+		paramsTemp, err := stmt.params.toParameters(stmt.defs)
+		if err != nil {
+			return nil, errors.ES(op, errors.KClientArgs, "QueryValues in the the Stmt were incorrect: %s", err).SetNoRetry()
+		}
+		params = paramsTemp
 	}
 
 	// Match our server deadline to our context.Deadline. This should be set from withing kusto.Query() to always have a value.

--- a/kusto/kusto_examples_test.go
+++ b/kusto/kusto_examples_test.go
@@ -3,6 +3,7 @@ package kusto
 import (
 	"context"
 	"fmt"
+	"github.com/Azure/azure-kusto-go/kusto/kql"
 	"io"
 	"net/http"
 	"net/url"
@@ -12,7 +13,6 @@ import (
 	kustoErrors "github.com/Azure/azure-kusto-go/kusto/data/errors"
 
 	"github.com/Azure/azure-kusto-go/kusto/data/table"
-	"github.com/Azure/azure-kusto-go/kusto/data/types"
 )
 
 func Example_simple() {
@@ -38,7 +38,7 @@ func Example_simple() {
 	ctx := context.Background()
 
 	// Query our database table "systemNodes" for the CollectionTimes and the NodeIds.
-	iter, err := client.Query(ctx, "database", NewStmt("systemNodes | project CollectionTime, NodeId"))
+	iter, err := client.Query(ctx, "database", kql.New("systemNodes | project CollectionTime, NodeId"))
 	if err != nil {
 		panic("add error handling")
 	}
@@ -74,30 +74,14 @@ func Example_simple() {
 
 func Example_complex() {
 	// This example sets up a Query where we want to query for nodes that have a NodeId (a Kusto Long type) that has a
-	// particular NodeId. The will require inserting a value where ParamNodeId is in the query. We create the query
-	// and attach a Definition to it that indicates which words we will be substituing for and what the expected type will be.
-	// the MustDefinitions() will panic if the Definition is not valid. There is a non-panicing version that returns an
-	// error instead.
-	rootStmt := NewStmt("systemNodes | project CollectionTime, NodeId | where NodeId == ParamNodeId").MustDefinitions(
-		NewDefinitions().Must(
-			ParamTypes{
-				"ParamNodeId": ParamType{Type: types.Long},
-			},
-		),
-	)
-
-	// This takes our rootStmt and creates a new Stmt that will insert 100 where ParamNodeId is in the rootStmt.
-	// rootStmt will remain unchanged. The Must() will panic if the QueryValues{} passed is not valid. This can
-	// happen because you use a type that isn't valid, like a string or int32.
-	// There is a non-panicing version that returns an error instead.
-	stmt, err := rootStmt.WithParameters(NewParameters().Must(QueryValues{"ParamNodeId": int64(100)}))
-	if err != nil {
-		panic("add error handling")
-	}
+	// particular NodeId. The will require inserting a value where ParamNodeId is in the query.
+	// We will used a parameterized query to do this.
+	query := kql.New("systemNodes | project CollectionTime, NodeId | where NodeId == ParamNodeId")
+	params := kql.NewParameters()
 
 	// NodeRec represents our Kusto data that will be returned.
 	type NodeRec struct {
-		// ID is the table's NodeId. We use the field tag here to to instruct our client to convert NodeId in the Kusto
+		// ID is the table's NodeId. We use the field tag here to instruct our client to convert NodeId in the Kusto
 		// table to ID in our struct.
 		ID int64 `kusto:"NodeId"`
 		// CollectionTime is Go representation of the Kusto datetime type.
@@ -117,15 +101,18 @@ func Example_complex() {
 
 	// Query our database table "systemNodes" for our specific node. We are only doing a single query here as an example,
 	// normally you would take in requests of some type for different NodeIds.
-	iter, err := client.Query(ctx, "database", stmt)
+	iter, err := client.Query(ctx, "database", query, QueryParameters(*params))
 	if err != nil {
 		panic("add error handling")
 	}
 	defer iter.Stop()
 
 	rec := NodeRec{} // We are assuming unique NodeId, so we will only get 1 row.
-	err = iter.Do(
-		func(row *table.Row) error {
+	err = iter.DoOnRowOrError(
+		func(row *table.Row, e *kustoErrors.Error) error {
+			if e != nil {
+				return e
+			}
 			return row.ToStruct(&rec)
 		},
 	)
@@ -172,7 +159,7 @@ func ExampleClient_Query_rows() {
 	ctx := context.Background()
 
 	// Query our database table "systemNodes" for the CollectionTimes and the NodeIds.
-	iter, err := client.Query(ctx, "database", NewStmt("systemNodes | project CollectionTime, NodeId"))
+	iter, err := client.Query(ctx, "database", kql.New("systemNodes | project CollectionTime, NodeId"))
 	if err != nil {
 		panic("add error handling")
 	}
@@ -181,7 +168,10 @@ func ExampleClient_Query_rows() {
 	// Iterate through the returned rows until we get an error or receive an io.EOF, indicating the end of
 	// the data being returned.
 	for {
-		row, err := iter.Next()
+		row, inlineErr, err := iter.NextRowOrError()
+		if inlineErr != nil {
+			panic("add error handling")
+		}
 		if err != nil {
 			if err == io.EOF {
 				break
@@ -215,7 +205,7 @@ func ExampleClient_Query_do() {
 	ctx := context.Background()
 
 	// Query our database table "systemNodes" for the CollectionTimes and the NodeIds.
-	iter, err := client.Query(ctx, "database", NewStmt("systemNodes | project CollectionTime, NodeId"))
+	iter, err := client.Query(ctx, "database", kql.New("systemNodes | project CollectionTime, NodeId"))
 	if err != nil {
 		panic("add error handling")
 	}
@@ -224,8 +214,11 @@ func ExampleClient_Query_do() {
 	// Iterate through the returned rows until we get an error or receive an io.EOF, indicating the end of
 	// the data being returned.
 
-	err = iter.Do(
-		func(row *table.Row) error {
+	err = iter.DoOnRowOrError(
+		func(row *table.Row, e *kustoErrors.Error) error {
+			if e != nil {
+				return e
+			}
 			if row.Replace {
 				fmt.Println("---") // Replace flag indicates that the query result should be cleared and replaced with this row
 			}
@@ -268,7 +261,7 @@ func ExampleClient_Query_struct() {
 	ctx := context.Background()
 
 	// Query our database table "systemNodes" for the CollectionTimes and the NodeIds.
-	iter, err := client.Query(ctx, "database", NewStmt("systemNodes | project CollectionTime, NodeId"))
+	iter, err := client.Query(ctx, "database", kql.New("systemNodes | project CollectionTime, NodeId"))
 	if err != nil {
 		panic("add error handling")
 	}
@@ -281,8 +274,11 @@ func ExampleClient_Query_struct() {
 	go func() {
 		// Note: we ignore the error here because we send it on a channel and an error will automatically
 		// end the iteration.
-		_ = iter.Do(
-			func(row *table.Row) error {
+		_ = iter.DoOnRowOrError(
+			func(row *table.Row, e *kustoErrors.Error) error {
+				if e != nil {
+					return e
+				}
 				rec := NodeRec{}
 				rec.err = row.ToStruct(&rec)
 				printCh <- rec

--- a/kusto/kusto_examples_test.go
+++ b/kusto/kusto_examples_test.go
@@ -101,7 +101,7 @@ func Example_complex() {
 
 	// Query our database table "systemNodes" for our specific node. We are only doing a single query here as an example,
 	// normally you would take in requests of some type for different NodeIds.
-	iter, err := client.Query(ctx, "database", query, QueryParameters(*params))
+	iter, err := client.Query(ctx, "database", query, QueryParameters(params))
 	if err != nil {
 		panic("add error handling")
 	}

--- a/kusto/mock.go
+++ b/kusto/mock.go
@@ -133,7 +133,7 @@ func (m mockConn) query(_ context.Context, _ string, _ Statement, _ *queryOption
 	return execResp{}, nil
 }
 
-func (m mockConn) mgmt(_ context.Context, _ string, _ Stmt, _ *mgmtOptions) (execResp, error) {
+func (m mockConn) mgmt(_ context.Context, _ string, _ Statement, _ *mgmtOptions) (execResp, error) {
 	framesCh := make(chan frames.Frame, 100)
 	framesCh <- v1.DataTable{}
 	close(framesCh)

--- a/kusto/mock_example_test.go
+++ b/kusto/mock_example_test.go
@@ -51,7 +51,7 @@ func New(client *kusto.Client) (*NodeInfo, error) {
 
 // Node queries the datastore for the Node with ID "id".
 func (n *NodeInfo) Node(ctx context.Context, id int64) (NodeRec, error) {
-	iter, err := n.querier.Query(ctx, "db", n.stmt, kusto.QueryParameters(*kql.NewParameters().AddLong("ParamNodeId", id)))
+	iter, err := n.querier.Query(ctx, "db", n.stmt, kusto.QueryParameters(kql.NewParameters().AddLong("ParamNodeId", id)))
 	if err != nil {
 		return NodeRec{}, err
 	}

--- a/kusto/mock_example_test.go
+++ b/kusto/mock_example_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	kustoErrors "github.com/Azure/azure-kusto-go/kusto/data/errors"
+	"github.com/Azure/azure-kusto-go/kusto/kql"
 	"testing"
 	"time"
 
@@ -36,7 +37,7 @@ type NodeRec struct {
 
 // NodeInfo is the type we are going to test.
 type NodeInfo struct {
-	stmt    kusto.Stmt
+	stmt    *kql.Builder
 	querier querier // This can be a fakeQuerier or *kusto.Client
 }
 
@@ -44,24 +45,13 @@ type NodeInfo struct {
 func New(client *kusto.Client) (*NodeInfo, error) {
 	return &NodeInfo{
 		querier: client,
-		stmt: kusto.NewStmt("systemNodes | project CollectionTime, NodeId | where NodeId == ParamNodeId").MustDefinitions(
-			kusto.NewDefinitions().Must(
-				kusto.ParamTypes{
-					"ParamNodeId": kusto.ParamType{Type: types.Long},
-				},
-			),
-		),
+		stmt:    kql.New("systemNodes | project CollectionTime, NodeId | where NodeId == ParamNodeId"),
 	}, nil
 }
 
 // Node queries the datastore for the Node with ID "id".
 func (n *NodeInfo) Node(ctx context.Context, id int64) (NodeRec, error) {
-	stmt, err := n.stmt.WithParameters(kusto.NewParameters().Must(kusto.QueryValues{"ParamNodeId": id}))
-	if err != nil {
-		return NodeRec{}, err
-	}
-
-	iter, err := n.querier.Query(ctx, "db", stmt)
+	iter, err := n.querier.Query(ctx, "db", n.stmt, kusto.QueryParameters(*kql.NewParameters().AddLong("ParamNodeId", id)))
 	if err != nil {
 		return NodeRec{}, err
 	}

--- a/kusto/query_builder.go
+++ b/kusto/query_builder.go
@@ -511,6 +511,7 @@ func UnsafeStmt(options unsafe.Stmt) StmtOption {
 	}
 }
 
+// Deprecated: Use kql.New and kql.NewParameters instead.
 // NewStmt creates a Stmt from a string constant.
 func NewStmt(query stringConstant, options ...StmtOption) Stmt {
 	s := Stmt{queryStr: query.String()}

--- a/kusto/queryopts.go
+++ b/kusto/queryopts.go
@@ -94,10 +94,10 @@ func Application(appName string) QueryOption {
 	}
 }
 
-// QueryParameters sets the
-func QueryParameters(queryParameters kql.Parameters) QueryOption {
+// QueryParameters sets the parameters to be used in the query.
+func QueryParameters(queryParameters *kql.Parameters) QueryOption {
 	return func(q *queryOptions) error {
-		q.requestProperties.QueryParameters = queryParameters
+		q.requestProperties.QueryParameters = *queryParameters
 		q.requestProperties.Parameters = queryParameters.ToParameterCollection()
 		return nil
 	}

--- a/kusto/statementBuilder_example_test.go
+++ b/kusto/statementBuilder_example_test.go
@@ -7,25 +7,25 @@ import (
 
 var (
 	// rootStatement represents our root statementBuilder object in which we can derive other statementBuilders.
-	rootStatement = kql.NewBuilder("").AddTable("systemNodes")
+	rootStatement = kql.New("").AddTable("systemNodes")
 	// singleBasicStatement is derived from the rootStatement but includes a where clause to limit the query to a wanted result.
 	singleBasicStatement = rootStatement.AddLiteral(" | where ").
 				AddColumn("NodeId").AddLiteral(" == ").AddInt(1)
 
 	// We will also define a similar Statement, but this time with a Parameters object as well to define the "NodeId" word in the
 	// query as an int (aka, using KQL query parameters).
-	singleParameterStatement = kql.NewBuilder("systemNodes").AddLiteral(" | where NodeId == id")
+	singleParameterStatement = kql.New("systemNodes").AddLiteral(" | where NodeId == id")
 	singleQueryParameter     = kql.NewParameters().AddInt("id", 1)
 )
 
 func ExampleStatement() {
 
 	// If we wanted to build a query , we could build it from singleBasicStatement like so :
-	fmt.Println("Basic Statement:\n", singleBasicStatement.String())
+	fmt.Println("Basic Builder:\n", singleBasicStatement.String())
 	// and send it to querying: client.Query(ctx, "database", singleBasicStatement)
 
 	// Or we can use the query parameters option:
-	fmt.Println("Basic Statement with parameters:\n", singleParameterStatement)
+	fmt.Println("Basic Builder with parameters:\n", singleParameterStatement)
 	for k, v := range singleQueryParameter.ToParameterCollection() {
 		fmt.Printf("Query parameters:\n{%s: %s}\n", k, v)
 	}
@@ -36,9 +36,9 @@ func ExampleStatement() {
 	fmt.Printf("Actual query:\n%s\n%s\n", singleQueryParameter.ToDeclarationString(), singleParameterStatement)
 
 	// Output:
-	// Basic Statement:
+	// Basic Builder:
 	//  systemNodes | where NodeId == int(1)
-	// Basic Statement with parameters:
+	// Basic Builder with parameters:
 	//  systemNodes | where NodeId == id
 	//Query parameters:
 	//{id: int(1)}

--- a/kusto/stmt_example_test.go
+++ b/kusto/stmt_example_test.go
@@ -2,9 +2,7 @@ package kusto_test
 
 import (
 	"fmt"
-
-	"github.com/Azure/azure-kusto-go/kusto"
-	"github.com/Azure/azure-kusto-go/kusto/data/types"
+	"github.com/Azure/azure-kusto-go/kusto/kql"
 )
 
 const (
@@ -19,85 +17,44 @@ const (
 var (
 	// rootStmt represents our root Stmt object in which we can derive other Stmts. This definition
 	// will always include NodeId and Version fields.
-	rootStmt = kusto.NewStmt(qRoot)
+	rootStmt = kql.New(qRoot)
 	// singleStmt is derived from the rootStmt but includes a where clause to limit the query to a
-	// single node. You will see that we input a Definitions object to define the "Node" word in the
-	// query as a string.
-	singleStmt = rootStmt.Add(singleNode).MustDefinitions(
-		kusto.NewDefinitions().Must(
-			kusto.ParamTypes{
-				"Node": kusto.ParamType{Type: types.String},
-			},
-		),
-	)
+	// single node. Node is an implicit parameter that will be substituted for a value when we run the query.
+	singleStmt = kql.FromBuilder(rootStmt).AddLiteral(singleNode)
 )
 
 func ExampleStmt() {
-	var err error
-
 	// This will print the rootStmt that could be used to list all nodes in the table.
-	fmt.Println("All Nodes Statement:\n", rootStmt.String())
+	fmt.Println("All Nodes Builder:")
+	fmt.Println(rootStmt.String())
 
-	// If we wanted to query for a single node, we could build a Stmt fron singleStmt like so:
-	params := kusto.NewParameters()
-	params, err = params.With(kusto.QueryValues{"Node": "my_id"}) // Substitute "my_id" in every place in the query where "Node" is
-	if err != nil {
-		panic(err)
-	}
+	// This will build the parameters for the singleStmt. We can use these parameters to run the query.
+	params := kql.NewParameters().AddString("Node", "my_id")
 
-	stmt, err := singleStmt.WithParameters(params)
-	if err != nil {
-		panic(err)
-	}
+	fmt.Println("Single Builder:")
+	fmt.Println(singleStmt.String())
+	fmt.Println("Single Builder Parameter declaration:")
+	fmt.Println(params.ToDeclarationString())
 
-	fmt.Println("Single Statement:\n", stmt)
-	j, err := stmt.ValuesJSON()
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println("Single Statement Parameters:\n", j)
+	// Alternatively, we can build the statement with the value in it.
+	stmt := kql.New(qRoot).AddLiteral("\n| where NodeId == ").AddString("my_id")
 
-	// Here is a more condensed version:
-	stmt, err = singleStmt.WithParameters(kusto.NewParameters().Must(kusto.QueryValues{"Node": "my_id2"}))
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Println("Single Statement(Condensed):\n", stmt)
-
-	// For repeated queries off a channel or loop, we can further optimize.
-	params = kusto.NewParameters()
-	qv := kusto.QueryValues{}
-
-	qv["Node"] = "node id from channel"
-	stmt, err = singleStmt.WithParameters(params.Must(qv))
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Println("Single Statement(Repeat):\n", stmt)
+	fmt.Println("Single Builder(Built):")
+	fmt.Println(stmt.String())
 
 	// Output:
-	// All Nodes Statement:
-	//  set notruncation;dcmInventoryComponentSystem
-	// | project NodeId, Version
-	// Single Statement:
-	//  declare query_parameters(Node:string);
-	// set notruncation;dcmInventoryComponentSystem
-	// | project NodeId, Version
-	// | where NodeId == Node
+	//All Nodes Builder:
+	//set notruncation;dcmInventoryComponentSystem
+	//| project NodeId, Version
+	//Single Builder:
+	//set notruncation;dcmInventoryComponentSystem
+	//| project NodeId, Version
+	//| where NodeId == Node
 	//
-	// Single Statement Parameters:
-	//  {"Node":"my_id"}
-	// Single Statement(Condensed):
-	//  declare query_parameters(Node:string);
-	// set notruncation;dcmInventoryComponentSystem
-	// | project NodeId, Version
-	// | where NodeId == Node
-	//
-	// Single Statement(Repeat):
-	//  declare query_parameters(Node:string);
-	// set notruncation;dcmInventoryComponentSystem
-	// | project NodeId, Version
-	// | where NodeId == Node
+	//Single Builder Parameter declaration:
+	//declare query_parameters(Node:string);
+	//Single Builder(Built):
+	//set notruncation;dcmInventoryComponentSystem
+	//| project NodeId, Version
+	//| where NodeId == "my_id"
 }

--- a/kusto/test/etoe/etoe_test.go
+++ b/kusto/test/etoe/etoe_test.go
@@ -42,7 +42,7 @@ var (
 	// This is needed because of a bug in the backend that sometimes causes the tables not to drop and get stuck.
 	clearStreamingCacheStatement = kql.New(".clear database cache streamingingestion schema")
 
-	countStatement = kql.New("table(tableName) | count()")
+	countStatement = kql.New("table(tableName) | count")
 )
 
 type CountResult struct {
@@ -143,7 +143,7 @@ func TestQueries(t *testing.T) {
 	}{
 		{
 			desc:  "Query: Retrieve count of the number of rows that match",
-			stmt:  countStatement,
+			stmt:  kql.New("").AddTable(allDataTypesTable).AddLiteral("| count"),
 			qcall: client.Query,
 			doer: func(row *table.Row, update interface{}) error {
 				rec := CountResult{}
@@ -309,7 +309,7 @@ func TestQueries(t *testing.T) {
 						"guid":      kusto.ParamType{Type: types.GUID},
 					})).
 				MustParameters(kusto.NewParameters().Must(kusto.
-					QueryValues{
+				QueryValues{
 					"tableName": allDataTypesTable,
 					"num":       int32(1),
 					"dec":       "2.00000000000001",
@@ -458,7 +458,7 @@ func TestQueries(t *testing.T) {
 		},
 		{
 			desc: "Query: Use many options",
-			stmt: countStatement,
+			stmt: kql.New("").AddTable(allDataTypesTable).AddLiteral("| count"),
 			options: []kusto.QueryOption{kusto.QueryNow(time.Now()), kusto.NoRequestTimeout(), kusto.NoTruncation(), kusto.RequestAppName("bd1e472c-a8e4-4c6e-859d-c86d72253197"),
 				kusto.RequestDescription("9bff424f-711d-48b8-9a6e-d3a618748334"), kusto.Application("aaa"), kusto.User("bbb"),
 				kusto.CustomQueryOption("additional", "additional")},
@@ -480,7 +480,7 @@ func TestQueries(t *testing.T) {
 		},
 		{
 			desc:   "Query: get json",
-			stmt:   countStatement,
+			stmt:   kql.New("").AddTable(allDataTypesTable).AddLiteral("| count"),
 			qjcall: client.QueryToJson,
 			want:   "[{\"FrameType\":\"DataSetHeader\",\"IsProgressive\":true,\"Version\":\"v2.0\"},{\"FrameType\":\"DataTable\",\"TableId\":<NUM>,\"TableKind\":\"QueryProperties\",\"TableName\":\"@ExtendedProperties\",\"Columns\":[{\"ColumnName\":\"TableId\",\"ColumnType\":\"int\"},{\"ColumnName\":\"Key\",\"ColumnType\":\"string\"},{\"ColumnName\":\"Value\",\"ColumnType\":\"dynamic\"}],\"Rows\":[[1,\"Visualization\",\"{\\\"Visualization\\\":null,\\\"Title\\\":null,\\\"XColumn\\\":null,\\\"Series\\\":null,\\\"YColumns\\\":null,\\\"AnomalyColumns\\\":null,\\\"XTitle\\\":null,\\\"YTitle\\\":null,\\\"XAxis\\\":null,\\\"YAxis\\\":null,\\\"Legend\\\":null,\\\"YSplit\\\":null,\\\"Accumulate\\\":false,\\\"IsQuerySorted\\\":false,\\\"Kind\\\":null,\\\"Ymin\\\":\\\"NaN\\\",\\\"Ymax\\\":\\\"NaN\\\",\\\"Xmin\\\":null,\\\"Xmax\\\":null}\"]]},{\"FrameType\":\"TableHeader\",\"TableId\":<NUM>,\"TableKind\":\"PrimaryResult\",\"TableName\":\"PrimaryResult\",\"Columns\":[{\"ColumnName\":\"Count\",\"ColumnType\":\"long\"}]},{\"FrameType\":\"TableFragment\",\"TableFragmentType\":\"DataAppend\",\"TableId\":<NUM>,\"Rows\":[[1]]},{\"FrameType\":\"TableProgress\",\"TableId\":<NUM>,\"TableProgress\"<TIME>},{\"FrameType\":\"TableCompletion\",\"TableId\":<NUM>,\"RowCount\":1},{\"FrameType\":\"DataTable\",\"TableId\":<NUM>,\"TableKind\":\"QueryCompletionInformation\",\"TableName\":\"QueryCompletionInformation\",\"Columns\":[{\"ColumnName\":\"Timestamp\",\"ColumnType\":\"datetime\"},{\"ColumnName\":\"ClientRequestId\",\"ColumnType\":\"string\"},{\"ColumnName\":\"ActivityId\",\"ColumnType\":\"guid\"},{\"ColumnName\":\"SubActivityId\",\"ColumnType\":\"guid\"},{\"ColumnName\":\"ParentActivityId\",\"ColumnType\":\"guid\"},{\"ColumnName\":\"Level\",\"ColumnType\":\"int\"},{\"ColumnName\":\"LevelName\",\"ColumnType\":\"string\"},{\"ColumnName\":\"StatusCode\",\"ColumnType\":\"int\"},{\"ColumnName\":\"StatusCodeName\",\"ColumnType\":\"string\"},{\"ColumnName\":\"EventType\",\"ColumnType\":\"int\"},{\"ColumnName\":\"EventTypeName\",\"ColumnType\":\"string\"},{\"ColumnName\":\"Payload\",\"ColumnType\":\"string\"}],\"Rows\":[[\"<TIME>\",\"KGC.execute;<GUID>\",\"<GUID>\",\"<GUID>\",\"<GUID>\",4,\"Info\",0,\"S_OK (0)\",4,\"QueryInfo\",\"{\\\"Count\\\":<NUM>,\\\"Text\\\":\\\"Query completed successfully\\\"}\"],[\"<TIME>\",\"KGC.execute;<GUID>\",\"<GUID>\",\"<GUID>\",\"<GUID>\",4,\"Info\",0,\"S_OK (0)\",5,\"WorkloadGroup\",\"{\\\"Count\\\":<NUM>,\\\"Text\\\":\\\"default\\\"}\"],[\"<TIME>\",\"KGC.execute;<GUID>\",\"<GUID>\",\"<GUID>\",\"<GUID>\",4,\"Info\",0,\"S_OK (0)\",6,\"EffectiveRequestOptions\",\"{\\\"Count\\\":<NUM>,\\\"Text\\\":\\\"{\\\\\\\"DataScope\\\\\\\":\\\\\\\"All\\\\\\\",\\\\\\\"QueryConsistency\\\\\\\":\\\\\\\"strongconsistency\\\\\\\",\\\\\\\"MaxMemoryConsumptionPerIterator\\\\\\\":<NUM>,\\\\\\\"MaxMemoryConsumptionPerQueryPerNode\\\\\\\":<NUM>,\\\\\\\"QueryFanoutNodesPercent\\\\\\\":<NUM>,\\\\\\\"QueryFanoutThreadsPercent\\\\\\\":100}\\\"}\"],[\"<TIME>\",\"KGC.execute;<GUID>\",\"<GUID>\",\"<GUID>\",\"<GUID>\",6,\"Stats\",0,\"S_OK (0)\",0,\"QueryResourceConsumption\",\"{\\\"ExecutionTime\\\"<TIME>,\\\"resource_usage\\\":{\\\"cache\\\":{\\\"memory\\\":{\\\"hits\\\":<NUM>,\\\"misses\\\":<NUM>,\\\"total\\\":0},\\\"disk\\\":{\\\"hits\\\":<NUM>,\\\"misses\\\":<NUM>,\\\"total\\\":0},\\\"shards\\\":{\\\"hot\\\":{\\\"hitbytes\\\":<NUM>,\\\"missbytes\\\":<NUM>,\\\"retrievebytes\\\":0},\\\"cold\\\":{\\\"hitbytes\\\":<NUM>,\\\"missbytes\\\":<NUM>,\\\"retrievebytes\\\":0},\\\"bypassbytes\\\":0}},\\\"cpu\\\":{\\\"user\\\":\\\"00:00:00\\\",\\\"kernel\\\":\\\"00:00:00\\\",\\\"total cpu\\\":\\\"00:00:00\\\"},\\\"memory\\\":{\\\"peak_per_node\\\":524384},\\\"network\\\":{\\\"inter_cluster_total_bytes\\\":<NUM>,\\\"cross_cluster_total_bytes\\\":0}},\\\"input_dataset_statistics\\\":{\\\"extents\\\":{\\\"total\\\":<NUM>,\\\"scanned\\\":<NUM>,\\\"scanned_min_datetime\\\":\\\"<TIME>\\\",\\\"scanned_max_datetime\\\":\\\"<TIME>\\\"},\\\"rows\\\":{\\\"total\\\":<NUM>,\\\"scanned\\\":0},\\\"rowstores\\\":{\\\"scanned_rows\\\":<NUM>,\\\"scanned_values_size\\\":0},\\\"shards\\\":{\\\"queries_generic\\\":<NUM>,\\\"queries_specialized\\\":0}},\\\"dataset_statistics\\\":[{\\\"table_row_count\\\":<NUM>,\\\"table_size\\\":9}],\\\"cross_cluster_resource_usage\\\":{}}\"]]},{\"FrameType\":\"DataSetCompletion\",\"HasErrors\":false,\"Cancelled\":false}]",
 		},
@@ -1010,7 +1010,7 @@ func TestFileIngestion(t *testing.T) { //ok
 			desc:     "Ingestion from local file test 2 queued",
 			ingestor: queuedIngestor,
 			src:      createCsvFileFromData(t, mockRows),
-			stmt:     kql.New("").AddTable(queuedTable).AddLiteral(" | order by header_api_version asc"),
+			stmt:     kql.New("table(tableName) | order by header_api_version asc"),
 			table:    queuedTable,
 			doer: func(row *table.Row, update interface{}) error {
 				rec := LogRow{}
@@ -1074,7 +1074,7 @@ func TestFileIngestion(t *testing.T) { //ok
 			desc:     "Ingestion from local file test 2 streaming",
 			ingestor: streamingIngestor,
 			src:      createCsvFileFromData(t, mockRows),
-			stmt:     kql.New("").AddTable(streamingTable).AddLiteral(" | order by header_api_version asc"),
+			stmt:     kql.New("table(tableName)  | order by header_api_version asc"),
 			table:    streamingTable,
 			doer: func(row *table.Row, update interface{}) error {
 				rec := LogRow{}
@@ -1337,7 +1337,7 @@ func TestReaderIngestion(t *testing.T) { // ok
 			options: []ingest.FileOption{
 				ingest.FileFormat(ingest.CSV),
 			},
-			stmt:  kql.New("").AddTable(queuedTable).AddLiteral(" | order by header_api_version asc"),
+			stmt:  kql.New("table(tableName) | order by header_api_version asc"),
 			table: queuedTable,
 			doer: func(row *table.Row, update interface{}) error {
 				rec := LogRow{}
@@ -1410,7 +1410,7 @@ func TestReaderIngestion(t *testing.T) { // ok
 				ingest.FileFormat(ingest.CSV),
 			},
 			src:   createCsvFileFromData(t, mockRows),
-			stmt:  kql.New("").AddTable(streamingTable).AddLiteral(" | order by header_api_version asc"),
+			stmt:  kql.New("table(tableName) | order by header_api_version asc"),
 			table: streamingTable,
 			doer: func(row *table.Row, update interface{}) error {
 				rec := LogRow{}
@@ -1462,8 +1462,9 @@ func TestReaderIngestion(t *testing.T) { // ok
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
+			var fTable string
 			if test.table != "" {
-				fTable := fmt.Sprintf("%s_%d_%d", test.table, time.Now().UnixNano(), rand.Int())
+				fTable = fmt.Sprintf("%s_%d_%d", test.table, time.Now().UnixNano(), rand.Int())
 				require.NoError(t, createIngestionTable(t, client, fTable, false))
 				test.options = append(test.options, ingest.Table(fTable))
 			}
@@ -1516,7 +1517,7 @@ func TestReaderIngestion(t *testing.T) { // ok
 				return
 			}
 
-			require.NoError(t, waitForIngest(t, ctx, client, testConfig.Database, "", test.stmt, test.doer, test.want, test.gotInit))
+			require.NoError(t, waitForIngest(t, ctx, client, testConfig.Database, fTable, test.stmt, test.doer, test.want, test.gotInit))
 		})
 	}
 }
@@ -1875,7 +1876,8 @@ func TestError(t *testing.T) {
 		t.Log("Closed client")
 	})
 
-	_, err = client.Query(context.Background(), testConfig.Database, countStatement)
+	_, err = client.Query(context.Background(), testConfig.Database, kql.New("table(tableName) | count"),
+		kusto.QueryParameters(kql.NewParameters().AddString("tableName", uuid.NewString())))
 
 	kustoError, ok := errors.GetKustoError(err)
 	require.True(t, ok)
@@ -2131,7 +2133,6 @@ func waitForIngest(t *testing.T, ctx context.Context, client *kusto.Client, data
 			} else {
 				iter, err = client.Query(ctx, database, stmt)
 			}
-
 			if err != nil {
 				return false, err
 			}

--- a/kusto/test/etoe/etoe_test.go
+++ b/kusto/test/etoe/etoe_test.go
@@ -309,7 +309,7 @@ func TestQueries(t *testing.T) {
 						"guid":      kusto.ParamType{Type: types.GUID},
 					})).
 				MustParameters(kusto.NewParameters().Must(kusto.
-				QueryValues{
+					QueryValues{
 					"tableName": allDataTypesTable,
 					"num":       int32(1),
 					"dec":       "2.00000000000001",

--- a/kusto/test/etoe/etoe_test.go
+++ b/kusto/test/etoe/etoe_test.go
@@ -42,7 +42,7 @@ var (
 	// This is needed because of a bug in the backend that sometimes causes the tables not to drop and get stuck.
 	clearStreamingCacheStatement = kql.New(".clear database cache streamingingestion schema")
 
-	countStatement = kql.New("table(tablename) | count()")
+	countStatement = kql.New("table(tableName) | count()")
 )
 
 type CountResult struct {

--- a/kusto/test/etoe/ingestion_status_e2e_test.go
+++ b/kusto/test/etoe/ingestion_status_e2e_test.go
@@ -57,8 +57,8 @@ func TestIngestionStatus(t *testing.T) {
 	require.NoError(t, err, "failed to reduce the default batching time")
 
 	// Refresh policy cache on DM
-	batchingStmt2 := kql.New(".refresh database ").AddDatabase(testConfig.Database).AddLiteral(
-		" table ").AddTable(tableName).AddLiteral(" cache ingestionbatchingpolicy")
+	batchingStmt2 := kql.New(".refresh database '").AddKeyword(testConfig.Database).AddLiteral(
+		"' table '").AddTable(tableName).AddLiteral("' cache ingestionbatchingpolicy")
 	_, err = client.Mgmt(ctx, "NetDefaultDB", batchingStmt2, kusto.IngestionEndpoint())
 
 	require.NoError(t, err, "failed to refresh policy cache on DM")

--- a/kusto/test/etoe/ingestion_status_e2e_test.go
+++ b/kusto/test/etoe/ingestion_status_e2e_test.go
@@ -57,8 +57,8 @@ func TestIngestionStatus(t *testing.T) {
 	require.NoError(t, err, "failed to reduce the default batching time")
 
 	// Refresh policy cache on DM
-	batchingStmt2 := kql.New(".refresh database '").AddDatabase(testConfig.Database).AddLiteral(
-		"' table '").AddTable(tableName).AddLiteral("' cache ingestionbatchingpolicy")
+	batchingStmt2 := kql.New(".refresh database ").AddDatabase(testConfig.Database).AddLiteral(
+		" table ").AddTable(tableName).AddLiteral(" cache ingestionbatchingpolicy")
 	_, err = client.Mgmt(ctx, "NetDefaultDB", batchingStmt2, kusto.IngestionEndpoint())
 
 	require.NoError(t, err, "failed to refresh policy cache on DM")

--- a/kusto/test/etoe/ingestion_status_e2e_test.go
+++ b/kusto/test/etoe/ingestion_status_e2e_test.go
@@ -3,6 +3,7 @@ package etoe
 import (
 	"context"
 	"fmt"
+	"github.com/Azure/azure-kusto-go/kusto/kql"
 	"io"
 	"os"
 	"strings"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/Azure/azure-kusto-go/kusto"
 	"github.com/Azure/azure-kusto-go/kusto/ingest"
-	"github.com/Azure/azure-kusto-go/kusto/unsafe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -51,14 +51,14 @@ func TestIngestionStatus(t *testing.T) {
 	require.NoError(t, err)
 
 	// Change the ingestion batching time
-	batchingStmt := kusto.NewStmt(".alter table ", kusto.UnsafeStmt(unsafe.Stmt{Add: true})).UnsafeAdd(tableName).Add(
+	batchingStmt := kql.New(".alter table ").AddTable(tableName).AddLiteral(
 		" policy ingestionbatching @'{ \"MaximumBatchingTimeSpan\": \"00:00:05\", \"MaximumNumberOfItems\": 500, \"MaximumRawDataSizeMB\": 1024 }' ")
 	_, err = client.Mgmt(ctx, testConfig.Database, batchingStmt)
 	require.NoError(t, err, "failed to reduce the default batching time")
 
 	// Refresh policy cache on DM
-	batchingStmt2 := kusto.NewStmt(".refresh database '", kusto.UnsafeStmt(unsafe.Stmt{Add: true})).UnsafeAdd(testConfig.Database).Add(
-		"' table '").UnsafeAdd(tableName).Add("' cache ingestionbatchingpolicy")
+	batchingStmt2 := kql.New(".refresh database '").AddDatabase(testConfig.Database).AddLiteral(
+		"' table '").AddTable(tableName).AddLiteral("' cache ingestionbatchingpolicy")
 	_, err = client.Mgmt(ctx, "NetDefaultDB", batchingStmt2, kusto.IngestionEndpoint())
 
 	require.NoError(t, err, "failed to refresh policy cache on DM")


### PR DESCRIPTION
### Added
* Mgmt now supports kql.Statement
* kql.FromBuilder to deplicate builders
### Changed
* Moved all examples and code to use the the new kql.Statement (except for code explictly testing/showing the old Stmt)
* Moved all examples away from deprecated methods
* kql.NewBuilder renamed simply to kql.New
### Fixed
* Made AddUnsafe public
### Removed
* kusto.NewStmt is now deprecated
### Security