### PR TITLE
Replace non-ascii characters in headers to be in line with the service.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 * Added kql.Builder struct for safe building of KQL statements from variables without use of 'Unsafe' mode.
-* Simpler handling of query parameters using kql.Parameters struct. 
+* Simpler handling of query parameters using kql.Parameters struct.
+### Fixed
+* Replace non-ascii characters in headers to be in line with the service.
 
 ## [0.11.3] - 2023-03-20
 ### Added

--- a/kusto/test/etoe/etoe_env.go
+++ b/kusto/test/etoe/etoe_env.go
@@ -89,5 +89,6 @@ func init() {
 	} else {
 		testConfig.kcsb = kusto.NewConnectionStringBuilder(testConfig.Endpoint).WithAadAppKey(testConfig.ClientID, testConfig.ClientSecret, testConfig.TenantID)
 	}
+	testConfig.kcsb.UserForTracing = "GoLang_E2ETest_ø"
 	skipETOE = false
 }

--- a/kusto/test/etoe/etoe_test.go
+++ b/kusto/test/etoe/etoe_test.go
@@ -106,7 +106,6 @@ func TestQueries(t *testing.T) {
 
 	_, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	testConfig.kcsb.UserForTracing = "GoLang_E2ETest_ø"
 	client, err := kusto.New(testConfig.kcsb)
 	if err != nil {
 		panic(err)

--- a/kusto/test/etoe/etoe_test.go
+++ b/kusto/test/etoe/etoe_test.go
@@ -106,7 +106,7 @@ func TestQueries(t *testing.T) {
 
 	_, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
+	testConfig.kcsb.UserForTracing = "GoLang_E2ETest_ø"
 	client, err := kusto.New(testConfig.kcsb)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
### Fixed
* Replace non-ascii characters in headers to be in line with the service.