### PR TITLE
Add error handling for OneAPIErrors in DataSetCompletion frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.12.1] - 2023-05-01
+### Fixed
+* Fixed parsing of errors in queries
 
 ## [0.12.0] - 2023-05-01
 ### Added

--- a/kusto/internal/frames/v2/decoder_test.go
+++ b/kusto/internal/frames/v2/decoder_test.go
@@ -465,9 +465,9 @@ func TestErrorDecode(t *testing.T) {
 			Op: errors.OpQuery,
 		},
 		DataSetCompletion{
-			Base:         Base{FrameType: "DataSetCompletion"},
-			HasErrors:    true,
-			Cancelled:    false,
+			Base:      Base{FrameType: "DataSetCompletion"},
+			HasErrors: true,
+			Cancelled: false,
 			OneAPIErrors: []interface{}{
 				map[string]interface{}{
 					"error": map[string]interface{}{

--- a/kusto/internal/version/version.go
+++ b/kusto/internal/version/version.go
@@ -2,4 +2,4 @@
 package version
 
 // Kusto is the version of this client package that is communicated to the server.
-const Kusto = "0.12.0"
+const Kusto = "0.12.1"

--- a/quickstart/go.mod
+++ b/quickstart/go.mod
@@ -2,7 +2,7 @@ module github.com/Azure/azure-kusto-go/quickstart
 
 go 1.19
 
-require github.com/Azure/azure-kusto-go v0.12.0
+require github.com/Azure/azure-kusto-go v0.12.1
 
 require (
     github.com/Azure/azure-pipeline-go v0.1.8 // indirect


### PR DESCRIPTION
### Added
### Changed
### Fixed
* Add proper error handling for OneAPIErrors in DataSetCompletion frame
### Removed
### Security
