### PR TITLE
fix: Assign ClientOptions if provided

### DIFF
--- a/kusto/kcsb.go
+++ b/kusto/kcsb.go
@@ -267,7 +267,7 @@ func (kcsb *ConnectionStringBuilder) WithInteractiveLogin(authorityID string) *C
 // Read more at https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azcore@v1.2.0/policy#ClientOptions
 func (kcsb *ConnectionStringBuilder) AttachPolicyClientOptions(options *azcore.ClientOptions) *ConnectionStringBuilder {
 	requireNonEmpty(dataSource, kcsb.DataSource)
-	if options == nil {
+	if options != nil {
 		kcsb.ClientOptions = options
 	}
 	return kcsb


### PR DESCRIPTION
Currently, the function `AttachPolicyClientOptions` doesn't do anything because the condition is wrong. Only nil options are assigned, which is not correct.
This PR solves the problem