### PR TITLE
Retry once when failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- Modified `once.go` to reset `sync.Once` instance when an error occurs
+
 ## [0.13.0] - 2023-05-09
 
 ### Added

--- a/kusto/utils/once.go
+++ b/kusto/utils/once.go
@@ -1,6 +1,9 @@
 package utils
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
 type Once[Out any] interface {
 	Do(f func() (Out, error)) (Out, error)
@@ -14,10 +17,10 @@ type OnceWithInit[Out any] interface {
 }
 
 type once[Out any] struct {
-	inner  sync.Once
+	mutex  sync.Mutex
 	result Out
 	err    error
-	done   bool
+	done   uint32
 }
 
 type onceWithInit[Out any] struct {
@@ -28,10 +31,10 @@ type onceWithInit[Out any] struct {
 func NewOnce[Out any]() Once[Out] {
 	var empty Out
 	return &once[Out]{
-		inner:  sync.Once{},
+		mutex:  sync.Mutex{},
 		result: empty,
 		err:    nil,
-		done:   false,
+		done:   0,
 	}
 }
 
@@ -58,21 +61,27 @@ func (o *onceWithInit[Out]) Result() (bool, Out, error) {
 }
 
 func (o *once[Out]) Do(f func() (Out, error)) (Out, error) {
-	o.inner.Do(func() {
+	if atomic.LoadUint32(&o.done) != 0 {
+		return o.result, o.err
+	}
+
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+	if o.done == 0 {
 		o.result, o.err = f()
-		o.done = o.err == nil
-	})
-	if o.err != nil {
-		o.inner = sync.Once{}
+
+		if o.err == nil {
+			defer atomic.StoreUint32(&o.done, 1)
+		}
 	}
 
 	return o.result, o.err
 }
 
 func (o *once[Out]) Done() bool {
-	return o.done
+	return o.done != 0
 }
 
 func (o *once[Out]) Result() (bool, Out, error) {
-	return o.done, o.result, o.err
+	return o.Done(), o.result, o.err
 }

--- a/kusto/utils/once.go
+++ b/kusto/utils/once.go
@@ -60,8 +60,12 @@ func (o *onceWithInit[Out]) Result() (bool, Out, error) {
 func (o *once[Out]) Do(f func() (Out, error)) (Out, error) {
 	o.inner.Do(func() {
 		o.result, o.err = f()
-		o.done = true
+		o.done = o.err == nil
 	})
+	if o.err != nil {
+		o.inner = sync.Once{}
+	}
+
 	return o.result, o.err
 }
 

--- a/kusto/utils/once_test.go
+++ b/kusto/utils/once_test.go
@@ -1,0 +1,115 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		withInit bool
+		useTwice bool
+		err      error
+	}{
+		{
+			name:     "Test Success",
+			withInit: false,
+		},
+		{
+			name:     "Test Success With Init",
+			withInit: true,
+		},
+		{
+			name:     "Test Failure",
+			withInit: false,
+			err:      errors.New("test"),
+		},
+		{
+			name:     "Test Failure With Init",
+			withInit: true,
+			err:      errors.New("test"),
+		},
+		{
+			name:     "Test Twice",
+			withInit: false,
+			err:      errors.New("test"),
+		},
+		{
+			name:     "Test Twice With Init",
+			withInit: true,
+			err:      errors.New("test"),
+		},
+	}
+
+	for _, test := range tests {
+		test := test // Capture
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			var f func() (int, error)
+			if test.useTwice {
+				counter := 0
+				f = func() (int, error) {
+					if counter == 0 {
+						counter++
+						return 0, errors.New("test")
+					} else {
+						return 1, nil
+					}
+				}
+			} else if test.err != nil {
+				f = func() (int, error) {
+					return 0, errors.New("test")
+				}
+			} else {
+				f = func() (int, error) {
+					return 1, nil
+				}
+			}
+
+			var result int
+			var err error
+			var once Once[int]
+			if test.withInit {
+				once = NewOnce[int]()
+				result, err = once.Do(f)
+			} else {
+				onceWithInit := NewOnceWithInit[int](f)
+				result, err = onceWithInit.DoWithInit()
+				once = onceWithInit
+			}
+
+			if test.useTwice {
+				isDone, onceResult, onceErr := once.Result()
+				assert.False(t, isDone)
+				assert.Equal(t, 0, onceResult)
+				assert.Equal(t, test.err, onceErr)
+				assert.Equal(t, test.err, err)
+				if test.withInit {
+					result, err = once.Do(f)
+				} else {
+					result, err = once.(OnceWithInit[int]).DoWithInit()
+				}
+				test.err = nil
+			}
+
+			isDone, onceResult, onceErr := once.Result()
+			if test.err != nil {
+				assert.False(t, isDone)
+				assert.Equal(t, 0, onceResult)
+				assert.Equal(t, test.err, onceErr)
+				assert.Equal(t, test.err, err)
+			} else {
+				assert.True(t, once.Done())
+				assert.True(t, isDone)
+				assert.Equal(t, 1, onceResult)
+				require.NoError(t, err)
+				assert.Equal(t, 1, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Changed
- Modified `once.go` to reset `sync.Once` instance when an error occurs (solves #188 )
