### PR TITLE
Added http support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Support streaming for blob, for Managed client as well.
+- Support more urls for kusto, including http and port.
 
 ### Fixed
   * Fixed wrong context deadline setting
+  * Fixed accepting empty url.
   
 ## [0.13.1] - 2023-05-24
 

--- a/kusto/conn.go
+++ b/kusto/conn.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -25,8 +24,6 @@ import (
 	truestedEndpoints "github.com/Azure/azure-kusto-go/kusto/trustedendpoints"
 	"github.com/google/uuid"
 )
-
-var validURL = regexp.MustCompile(`https://([a-zA-Z0-9_-]+\.){1,2}.*`)
 
 var bufferPool = sync.Pool{
 	New: func() interface{} {
@@ -46,14 +43,19 @@ type Conn struct {
 
 // NewConn returns a new Conn object with an injected http.Client
 func NewConn(endpoint string, auth Authorization, client *http.Client, clientDetails *ClientDetails) (*Conn, error) {
-	if !validURL.MatchString(endpoint) {
-		return nil, errors.ES(errors.OpServConn, errors.KClientArgs, "endpoint is not valid(%s), should be https://<cluster name>.*", endpoint).SetNoRetry()
-	}
-
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, errors.ES(errors.OpServConn, errors.KClientArgs, "could not parse the endpoint(%s): %s", endpoint, err).SetNoRetry()
 	}
+
+	if endpoint == "" {
+		return nil, errors.ES(errors.OpQuery, errors.KClientArgs, "endpoint cannot be empty")
+	}
+
+	if (u.Scheme == "http") && auth.TokenProvider.AuthorizationRequired() {
+		return nil, errors.ES(errors.OpServConn, errors.KClientArgs, "cannot use token provider with http endpoint, as it would send the token in clear text").SetNoRetry()
+	}
+
 	if !strings.HasPrefix(u.Path, "/") {
 		u.Path = "/" + u.Path
 	}
@@ -65,6 +67,7 @@ func NewConn(endpoint string, auth Authorization, client *http.Client, clientDet
 		endStreamIngest: u.JoinPath("/v1/rest/ingest"),
 		client:          client,
 		clientDetails:   clientDetails,
+		endpoint:        endpoint,
 	}
 
 	return c, nil

--- a/kusto/conn.go
+++ b/kusto/conn.go
@@ -52,7 +52,7 @@ func NewConn(endpoint string, auth Authorization, client *http.Client, clientDet
 		return nil, errors.ES(errors.OpQuery, errors.KClientArgs, "endpoint cannot be empty")
 	}
 
-	if (u.Scheme == "http") && auth.TokenProvider.AuthorizationRequired() {
+	if (u.Scheme != "https") && auth.TokenProvider.AuthorizationRequired() {
 		return nil, errors.ES(errors.OpServConn, errors.KClientArgs, "cannot use token provider with http endpoint, as it would send the token in clear text").SetNoRetry()
 	}
 


### PR DESCRIPTION
### Added
- Support more urls for kusto, including http and port.

### Fixed
  * Fixed wrong context deadline setting
  * Fixed accepting empty url.