### PR TITLE
Report size of original reader - not the compressed size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.2] - 2023-11-08
+
+### Fixed
+
+-  Size used for RawDataSize taken from gzip reader was of the gzip size and not the original reader size 
+
 ## [0.14.1] - 2023-09-27
 
 ### Added

--- a/kusto/ingest/internal/gzip/gzip.go
+++ b/kusto/ingest/internal/gzip/gzip.go
@@ -43,7 +43,7 @@ func (s *Streamer) Reset(reader io.ReadCloser) {
 // InputSize returns the amount of data that the Streamer streamed. This will only be accurate for
 // the full stream after Read() has returned io.EOF and not before.
 func (s *Streamer) InputSize() int64 {
-	return atomic.LoadInt64(&s.size)
+	return s.size
 }
 
 func Compress(payload io.Reader) io.Reader {
@@ -70,7 +70,7 @@ func (s *Streamer) run() {
 		defer zw.Flush()
 
 		amount, err := io.Copy(zw, s.userInput)
-		atomic.AddInt64(&s.size, int64(amount))
+		s.size = int64(amount)
 
 		if err != nil {
 			s.err.Store(err)

--- a/kusto/ingest/internal/gzip/gzip.go
+++ b/kusto/ingest/internal/gzip/gzip.go
@@ -69,7 +69,9 @@ func (s *Streamer) run() {
 		defer zw.Close()
 		defer zw.Flush()
 
-		_, err := io.Copy(zw, s.userInput)
+		amount, err := io.Copy(zw, s.userInput)
+		atomic.AddInt64(&s.size, int64(amount))
+
 		if err != nil {
 			s.err.Store(err)
 		}
@@ -79,7 +81,6 @@ func (s *Streamer) run() {
 // Read implements io.Reader.
 func (s *Streamer) Read(b []byte) (int, error) {
 	amount, err := s.outputRead.Read(b)
-	atomic.AddInt64(&s.size, int64(amount))
 	return amount, err
 }
 

--- a/kusto/ingest/internal/gzip/gzip_test.go
+++ b/kusto/ingest/internal/gzip/gzip_test.go
@@ -60,4 +60,8 @@ func TestStreamer(t *testing.T) {
 	if gotBuf.String() != str {
 		t.Fatalf("TestStreamer(input/output comparison): after compression/decompression the data was not the same")
 	}
+
+	if int64(len(str)) != streamer.InputSize() {
+		t.Fatalf("TestStreamer(InputSize): got %d, want %d", streamer.InputSize(), len(str))
+	}
 }


### PR DESCRIPTION
### Fixed
-     Size used for RawDataSize taken from gzip reader was of the gzip size and not the original reader size
