### PR TITLE
Resource mgr keep original error

### DIFF
--- a/azkustoingest/internal/resources/resources.go
+++ b/azkustoingest/internal/resources/resources.go
@@ -390,7 +390,7 @@ func (m *Manager) fetchRetry(ctx context.Context) error {
 		if err != nil {
 			attempts++
 			if attempts > retryCount {
-				return fmt.Errorf("failed to fetch ingestion resources")
+				return fmt.Errorf("failed to fetch ingestion resources: %w", err)
 			}
 			time.Sleep(10 * time.Second)
 			continue

--- a/azkustoingest/internal/resources/resources.go
+++ b/azkustoingest/internal/resources/resources.go
@@ -6,14 +6,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-kusto-go/azkustodata"
-	"github.com/Azure/azure-kusto-go/azkustodata/query"
-	v1 "github.com/Azure/azure-kusto-go/azkustodata/query/v1"
 	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/Azure/azure-kusto-go/azkustodata"
+	"github.com/Azure/azure-kusto-go/azkustodata/query"
+	v1 "github.com/Azure/azure-kusto-go/azkustodata/query/v1"
 
 	kustoErrors "github.com/Azure/azure-kusto-go/azkustodata/errors"
 	"github.com/Azure/azure-kusto-go/azkustodata/kql"
@@ -32,25 +33,19 @@ type mgmter interface {
 	Mgmt(ctx context.Context, db string, statement azkustodata.Statement, options ...azkustodata.QueryOption) (v1.Dataset, error)
 }
 
-var objectTypes = map[string]bool{
-	"queue": true,
-	"blob":  true,
-	"table": true,
-}
-
 // URI represents a resource URI for an ingestion command.
 type URI struct {
-	u                               *url.URL
-	account, objectType, objectName string
-	sas                             url.Values
+	u                   *url.URL
+	account, objectName string
+	sas                 url.Values
 }
 
 // Parse parses a string representing a Kutso resource URI.
-func Parse(uri string) (*URI, error) {
+func Parse(resourceUri string) (*URI, error) {
 	// Example for a valid url:
 	// https://fkjsalfdks.blob.core.windows.com/sdsadsadsa?sas=asdasdasd
 
-	u, err := url.Parse(uri)
+	u, err := url.Parse(resourceUri)
 	if err != nil {
 		return nil, err
 	}
@@ -59,28 +54,11 @@ func Parse(uri string) (*URI, error) {
 		return nil, fmt.Errorf("URI scheme must be 'https', was '%s'", u.Scheme)
 	}
 
-	hostSplit := strings.Split(u.Hostname(), ".")
-	if len(hostSplit) < 5 {
-		return nil, fmt.Errorf("error: Storage URI (%s) is invalid'", uri)
-	}
-
-	var v *URI
-	if len(hostSplit) == 5 {
-		v = &URI{
-			u:          u,
-			account:    hostSplit[0],
-			objectType: hostSplit[1],
-			objectName: strings.TrimLeft(u.EscapedPath(), "/"),
-			sas:        u.Query(),
-		}
-	} else {
-		v = &URI{
-			u:          u,
-			account:    hostSplit[0] + "." + hostSplit[1],
-			objectType: hostSplit[2],
-			objectName: strings.TrimLeft(u.EscapedPath(), "/"),
-			sas:        u.Query(),
-		}
+	v := &URI{
+		u:          u,
+		account:    u.Hostname(),
+		objectName: strings.TrimLeft(u.EscapedPath(), "/"),
+		sas:        u.Query(),
 	}
 
 	if err := v.validate(); err != nil {
@@ -90,31 +68,16 @@ func Parse(uri string) (*URI, error) {
 	return v, nil
 }
 
-// validate validates that the URI was valid.
-// TODO(Daniel): You could add deep validation of each value we have split to give better diagnostic info on an error.
-// I put in the most basic evalutation, but you might want to put checks for the account format or objectName foramt.
 func (u *URI) validate() error {
-	if u.account == "" {
-		return fmt.Errorf("account name was not provided")
-	}
-	if !objectTypes[u.objectType] {
-		return fmt.Errorf("object type was not valid(queue|blob|table), was: %q", u.objectType)
-	}
 	if u.objectName == "" {
 		return fmt.Errorf("object name was not provided")
 	}
-
 	return nil
 }
 
 // Account is the Azure storage account that will be used.
 func (u *URI) Account() string {
 	return u.account
-}
-
-// ObjectType returns the type of object that will be ingested: queue, blob or table.
-func (u *URI) ObjectType() string {
-	return u.objectType
 }
 
 // ObjectName returns the object name of the resource, i.e container name.

--- a/azkustoingest/internal/resources/resources_test.go
+++ b/azkustoingest/internal/resources/resources_test.go
@@ -2,8 +2,9 @@ package resources
 
 import (
 	"context"
-	v1 "github.com/Azure/azure-kusto-go/azkustodata/query/v1"
 	"testing"
+
+	v1 "github.com/Azure/azure-kusto-go/azkustodata/query/v1"
 
 	"github.com/stretchr/testify/assert"
 
@@ -19,24 +20,8 @@ func TestParse(t *testing.T) {
 		url            string
 		err            bool
 		wantAccount    string
-		wantObjectType string
 		wantObjectName string
 	}{
-		{
-			desc: "account is missing, but has leading dot",
-			url:  "https://.queue.core.windows.net/objectname",
-			err:  true,
-		},
-		{
-			desc: "account is missing",
-			url:  "https://queue.core.windows.net/objectname",
-			err:  true,
-		},
-		{
-			desc: "invalid object type",
-			url:  "https://account.invalid.core.windows.net/objectname",
-			err:  true,
-		},
 		{
 			desc: "no object name provided",
 			url:  "https://account.invalid.core.windows.net/",
@@ -50,22 +35,19 @@ func TestParse(t *testing.T) {
 		{
 			desc:           "success",
 			url:            "https://account.table.core.windows.net/objectname",
-			wantAccount:    "account",
-			wantObjectType: "table",
+			wantAccount:    "account.table.core.windows.net",
 			wantObjectName: "objectname",
 		},
 		{
 			desc:           "success non-public",
 			url:            "https://account.table.kusto.chinacloudapi.cn/objectname",
-			wantAccount:    "account",
-			wantObjectType: "table",
+			wantAccount:    "account.table.kusto.chinacloudapi.cn",
 			wantObjectName: "objectname",
 		},
 		{
 			desc:           "success dns zone",
-			url:            "https://account.zone1.blob.storage.azure.net/objectname",
-			wantAccount:    "account.zone1",
-			wantObjectType: "blob",
+			url:            "https://account.z01.blob.storage.azure.net/objectname",
+			wantAccount:    "account.z01.blob.storage.azure.net",
 			wantObjectName: "objectname",
 		},
 	}
@@ -84,7 +66,6 @@ func TestParse(t *testing.T) {
 			assert.NoError(t, err)
 
 			assert.Equal(t, test.wantAccount, got.Account())
-			assert.Equal(t, test.wantObjectType, got.ObjectType())
 			assert.Equal(t, test.wantObjectName, got.ObjectName())
 			assert.Equal(t, test.url, got.String())
 		})
@@ -204,7 +185,7 @@ func TestResources(t *testing.T) {
 				[]value.Values{
 					{
 						value.NewString("TempStorage"),
-						value.NewString("https://.blob.core.windows.net/storageroot"),
+						value.NewString("https://.blob.core.windows.net/"),
 					},
 				},
 				false,


### PR DESCRIPTION
1.return original error when failing to refresh ingestion resources.
2.fix resource URI parsing for URI with long hostname.