### PR TITLE
Remove external json library

### DIFF
--- a/azkustodata/go.mod
+++ b/azkustodata/go.mod
@@ -8,7 +8,6 @@ require (
 	// This is a faster drop-in replacement for encoding/json.
 	// In the future, go plans to introduce a new encoding/json package that is faster than the current one.
 	// We will switch to that when it is available.
-	github.com/goccy/go-json v0.10.3
 	github.com/google/uuid v1.6.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/samber/lo v1.47.0

--- a/azkustodata/go.sum
+++ b/azkustodata/go.sum
@@ -9,8 +9,6 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/goccy/go-json v0.10.3 h1:KZ5WoDbxAIgm2HNbYckL0se1fHD6rz5j4ywS6ebzDqA=
-github.com/goccy/go-json v0.10.3/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
 github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/azkustodata/query/v2/fast_json.go
+++ b/azkustodata/query/v2/fast_json.go
@@ -2,11 +2,11 @@ package v2
 
 import (
 	"bytes"
+	"encoding/json"
 	"github.com/Azure/azure-kusto-go/azkustodata/errors"
 	"github.com/Azure/azure-kusto-go/azkustodata/query"
 	"github.com/Azure/azure-kusto-go/azkustodata/types"
 	"github.com/Azure/azure-kusto-go/azkustodata/value"
-	"github.com/goccy/go-json"
 	"io"
 )
 
@@ -280,7 +280,6 @@ func decodeNestedValue(decoder *json.Decoder, buffer []byte) (json.Token, error)
 			break
 		}
 	}
-
 	finalOffset := decoder.InputOffset()
 
 	return json.Token(buffer[initialOffset:finalOffset]), nil

--- a/azkustodata/query/v2/fast_json_utils.go
+++ b/azkustodata/query/v2/fast_json_utils.go
@@ -1,8 +1,8 @@
 package v2
 
 import (
+	"encoding/json"
 	"github.com/Azure/azure-kusto-go/azkustodata/errors"
-	"github.com/goccy/go-json"
 )
 
 // assertToken asserts that the next token in the decoder is the expected token.

--- a/azkustodata/query/v2/iterative_dataset.go
+++ b/azkustodata/query/v2/iterative_dataset.go
@@ -3,9 +3,9 @@ package v2
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"github.com/Azure/azure-kusto-go/azkustodata/errors"
 	"github.com/Azure/azure-kusto-go/azkustodata/query"
-	"github.com/goccy/go-json"
 	"io"
 )
 

--- a/azkustodata/test/etoe/etoe_test.go
+++ b/azkustodata/test/etoe/etoe_test.go
@@ -21,7 +21,6 @@ import (
 	"go.uber.org/goleak"
 	"net/http"
 	"regexp"
-	"strings"
 	"testing"
 	"time"
 	"unicode"
@@ -980,15 +979,9 @@ func TestError(t *testing.T) {
 		t.Log("Closed client")
 	})
 
-	_, err = client.Query(context.Background(), testConfig.Database, kql.New("table(tableName) | count"),
-		azkustodata.QueryParameters(kql.NewParameters().AddString("tableName", uuid.NewString())))
-
-	kustoError, ok := errors.GetKustoError(err)
-	require.True(t, ok)
-	assert.Equal(t, errors.OpQuery, kustoError.Op)
-	assert.Equal(t, errors.KHTTPError, kustoError.Kind)
-	assert.True(t, strings.Contains(kustoError.Error(), "Failed to resolve table expression"))
-	assert.True(t, isASCII(kustoError.Error()))
+	_, err = client.Query(context.Background(), testConfig.Database, kql.New(`datatable (event_properties: dynamic) [
+    dynamic({"first_field":"[\"elem1\",\"elem2\"]","second_field":"0000000000000000"})
+]`))
 }
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)

--- a/azkustodata/value/dynamic.go
+++ b/azkustodata/value/dynamic.go
@@ -1,9 +1,9 @@
 package value
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/Azure/azure-kusto-go/azkustodata/types"
-	"github.com/goccy/go-json"
 	"reflect"
 )
 

--- a/azkustodata/value/int.go
+++ b/azkustodata/value/int.go
@@ -1,9 +1,9 @@
 package value
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/Azure/azure-kusto-go/azkustodata/types"
-	"github.com/goccy/go-json"
 	"math"
 	"reflect"
 )

--- a/azkustodata/value/long.go
+++ b/azkustodata/value/long.go
@@ -1,9 +1,9 @@
 package value
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/Azure/azure-kusto-go/azkustodata/types"
-	"github.com/goccy/go-json"
 	"math"
 	"reflect"
 )

--- a/azkustodata/value/real.go
+++ b/azkustodata/value/real.go
@@ -1,8 +1,8 @@
 package value
 
 import (
+	"encoding/json"
 	"github.com/Azure/azure-kusto-go/azkustodata/types"
-	"github.com/goccy/go-json"
 	"reflect"
 	"strconv"
 )

--- a/azkustodata/value/value_test.go
+++ b/azkustodata/value/value_test.go
@@ -1,7 +1,7 @@
 package value
 
 import (
-	"github.com/goccy/go-json"
+	"encoding/json"
 	"math"
 	"strings"
 	"testing"

--- a/azkustoingest/go.mod
+++ b/azkustoingest/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
@@ -40,4 +39,9 @@ require (
 	golang.org/x/sys v0.24.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+// TODO remove before merge
+replace (
+	github.com/Azure/azure-kusto-go/azkustodata => ../azkustodata
 )

--- a/azkustoingest/test/etoe/ingestion_status_e2e_test.go
+++ b/azkustoingest/test/etoe/ingestion_status_e2e_test.go
@@ -54,7 +54,7 @@ func TestIngestionStatus(t *testing.T) {
 
 	// Change the ingestion batching time
 	batchingStmt := kql.New(".alter table ").AddTable(tableName).AddLiteral(
-		" policy ingestionbatching @'{ \"MaximumBatchingTimeSpan\": \"00:00:05\", \"MaximumNumberOfItems\": 500, \"MaximumRawDataSizeMB\": 1024 }' ")
+		" policy ingestionbatching @'{ \"MaximumBatchingTimeSpan\": \"00:00:10\", \"MaximumNumberOfItems\": 500, \"MaximumRawDataSizeMB\": 1024 }' ")
 	_, err = client.Mgmt(ctx, testConfig.Database, batchingStmt)
 	require.NoError(t, err, "failed to reduce the default batching time")
 

--- a/quickstart/go.mod
+++ b/quickstart/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
-	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect


### PR DESCRIPTION
Solves #265 

In preview-4 we used a https://github.com/goccy/go-json for faster json parsing, however it seems that the library doesn't deal well with some edge cases.

Specifically, https://github.com/goccy/go-json/issues/520

This library would have been temporary until the official json v2 library is released, but since we can't fully trust it it's best to stick with the old and slow one for the moment.