### PR TITLE
Auth metadata endpoint is always rooted.

### DIFF
--- a/azkustodata/cloudinfo.go
+++ b/azkustodata/cloudinfo.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 	"sync"
 )
 
@@ -65,10 +64,11 @@ func GetMetadata(kustoUri string, httpClient *http.Client) (CloudInfo, error) {
 		if err != nil {
 			return CloudInfo{}, err
 		}
-		if !strings.HasPrefix(u.Path, "/") {
-			u.Path = "/" + u.Path
-		}
-		u = u.JoinPath(metadataPath)
+
+		// Auth metadata is always at the root of the cluster
+		u.Path = metadataPath
+		u.RawQuery = ""
+
 		// TODO should we make this timeout configurable.
 		req, err := http.NewRequest("GET", u.String(), nil)
 

--- a/azkustodata/cloudinfo_test.go
+++ b/azkustodata/cloudinfo_test.go
@@ -25,7 +25,7 @@ func newTestServ() *server {
 func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer log.Println("server exited")
 	w.WriteHeader(s.code)
-	if s.code == 200 {
+	if s.code == 200 && r.RequestURI == metadataPath {
 		_, _ = w.Write(s.payload)
 	}
 }
@@ -95,7 +95,7 @@ func TestGetMetadata(t *testing.T) {
 			desc:    "Internal server error",
 			payload: "",
 			want:    CloudInfo{},
-			errwant: fmt.Sprintf("Op(Op(6)): Kind(KHTTPError): error 500 Internal Server Error when querying endpoint %s/test_cloud_info_internal_error%s", s.urlStr(), metadataPath),
+			errwant: fmt.Sprintf("Op(Op(6)): Kind(KHTTPError): error 500 Internal Server Error when querying endpoint %s%s", s.urlStr(), metadataPath),
 		},
 		{
 			name:    "test_cloud_info_missing_key",


### PR DESCRIPTION
### Fixed
Auth metadata endpoint is always rooted
