### PR TITLE
Fix JSON marshaling for tags in `Ingestion.Additional.Tags`

### DIFF
--- a/azkustoingest/internal/properties/properties.go
+++ b/azkustoingest/internal/properties/properties.go
@@ -278,6 +278,16 @@ type Ingestion struct {
 	ClientVersionForTracing string `json:",omitempty"`
 }
 
+type TagsList []string
+
+func (t TagsList) MarshalJSON() ([]byte, error) {
+	j, err := json.Marshal([]string(t))
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(j))
+}
+
 // Additional is additional properites.
 type Additional struct {
 	// AuthContext is the authorization string that we get from resources.Manager.AuthContext().
@@ -296,7 +306,7 @@ type Additional struct {
 	Format            DataFormat `json:"format,omitempty"`
 	IgnoreFirstRecord bool       `json:"ignoreFirstRecord"`
 	// Tags is a list of tags to associated with the ingested data.
-	Tags []string `json:"tags,omitempty"`
+	Tags TagsList `json:"tags,omitempty"`
 	// IngestIfNotExists is a string value that, if specified, prevents ingestion from succeeding if the table already
 	// has data tagged with an ingest-by: tag with the same value. This ensures idempotent data ingestion.
 	IngestIfNotExists string `json:"ingestIfNotExists,omitempty"`

--- a/azkustoingest/internal/properties/properties_test.go
+++ b/azkustoingest/internal/properties/properties_test.go
@@ -1,0 +1,85 @@
+package properties
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIngestionJSONMarshal(t *testing.T) {
+	ingestion := Ingestion{
+		ID:                        uuid.MustParse("9854e507-5060-4fed-be22-e909780245fb"),
+		BlobPath:                  "https://test.blob.core.windows.net/test/test.csv",
+		DatabaseName:              "NetDefaultDB",
+		TableName:                 "TestTable",
+		RawDataSize:               1337,
+		RetainBlobOnSuccess:       true,
+		FlushImmediately:          true,
+		IgnoreSizeLimit:           true,
+		ReportLevel:               FailureAndSuccess,
+		ReportMethod:              ReportStatusToTable,
+		SourceMessageCreationTime: time.Unix(0, 0).UTC(),
+		Additional: Additional{
+			AuthContext:          "e30=",
+			IngestionMapping:     "Map",
+			IngestionMappingRef:  "MapRef",
+			IngestionMappingType: ApacheAVRO,
+			ValidationPolicy:     "{}",
+			Format:               ApacheAVRO,
+			IgnoreFirstRecord:    true,
+			Tags:                 []string{"blue", "green"},
+			IngestIfNotExists:    "yellow",
+			CreationTime:         time.Unix(0, 0).UTC(),
+		},
+		TableEntryRef: StatusTableDescription{
+			TableConnectionString: "connString",
+			PartitionKey:          "10f76b1f-0c57-4844-a354-a08d7b9ee627",
+			RowKey:                "00000000-0000-0000-0000-000000000000",
+		},
+		ApplicationForTracing:   "app;test",
+		ClientVersionForTracing: "TraceValue",
+	}
+
+	expected := map[string]any{
+		"Id":                        "9854e507-5060-4fed-be22-e909780245fb",
+		"BlobPath":                  "https://test.blob.core.windows.net/test/test.csv",
+		"DatabaseName":              "NetDefaultDB",
+		"TableName":                 "TestTable",
+		"RawDataSize":               float64(1337),
+		"RetainBlobOnSuccess":       true,
+		"FlushImmediately":          true,
+		"IgnoreSizeLimit":           true,
+		"ReportLevel":               float64(2),
+		"ReportMethod":              float64(1),
+		"SourceMessageCreationTime": "1970-01-01T00:00:00Z",
+		"AdditionalProperties": map[string]any{
+			"authorizationContext":      "e30=",
+			"ingestionMapping":          "Map",
+			"ingestionMappingReference": "MapRef",
+			"ingestionMappingType":      "ApacheAvro",
+			"validationPolicy":          "{}",
+			"format":                    "avro",
+			"ignoreFirstRecord":         true,
+			"tags":                      "[\"blue\",\"green\"]",
+			"ingestIfNotExists":         "yellow",
+			"creationTime":              "1970-01-01T00:00:00Z",
+		},
+		"IngestionStatusInTable": map[string]any{
+			"TableConnectionString": "connString",
+			"PartitionKey":          "10f76b1f-0c57-4844-a354-a08d7b9ee627",
+			"RowKey":                "00000000-0000-0000-0000-000000000000",
+		},
+		"ApplicationForTracing":   "app;test",
+		"ClientVersionForTracing": "TraceValue",
+	}
+
+	j, err := json.Marshal(ingestion)
+	assert.NoError(t, err)
+
+	var actual map[string]any
+	err = json.Unmarshal(j, &actual)
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
Introduce `TagsList` type with custom marshaling logic to ensure correct formatting.
Tags should be a string containing a JSON-encoded array of tags.

### Added
### Changed
### Fixed
fixes #304
### Removed
### Security
