### PR TITLE
Fix queued compression metadata handling

### DIFF
--- a/azkustoingest/ingestoptions/ingestoptions.go
+++ b/azkustoingest/ingestoptions/ingestoptions.go
@@ -14,6 +14,19 @@ func (c CompressionType) String() string {
 	return "unknown compression type"
 }
 
+// ToFileExtension returns the standard file extension for the compression type,
+// without a leading dot.
+func (c CompressionType) ToFileExtension() (string, bool) {
+	switch c {
+	case GZIP:
+		return "gz", true
+	case ZIP:
+		return "zip", true
+	default:
+		return "", false
+	}
+}
+
 //goland:noinspection GoUnusedConst - Part of the API
 const (
 	// CTUnknown indicates that that the compression type was unset.

--- a/azkustoingest/internal/queued/queued.go
+++ b/azkustoingest/internal/queued/queued.go
@@ -190,7 +190,7 @@ func (i *Ingestion) UploadReaderToBlob(ctx context.Context, reader io.Reader, pr
 		return "", 0, errors.ES(errors.OpFileIngest, errors.KBlobstore, "no Kusto queue resources are defined, there is no queue to upload to").SetNoRetry()
 	}
 
-	compression := utils.CompressionDiscovery(props.Source.OriginalSource)
+	compression := effectiveCompressionType(&props, props.Source.OriginalSource)
 	shouldCompress := ShouldCompress(&props, compression)
 	blobName := GenBlobName(i.db, i.table, nower(), filepath.Base(uuid.New().String()), filepath.Base(props.Source.OriginalSource), compression, shouldCompress, props.Ingestion.Additional.Format.String())
 	seeker, isSeekable := reader.(io.Seeker)
@@ -353,7 +353,7 @@ var nower = time.Now
 // localToBlob copies from a local to an Azure Blobstore blob. It returns the URL of the Blob, the local file info and an
 // error if there was one.
 func (i *Ingestion) localToBlob(ctx context.Context, from string, client *azblob.Client, container string, props *properties.All) (string, int64, error) {
-	compression := utils.CompressionDiscovery(from)
+	compression := effectiveCompressionType(props, from)
 	shouldCompress := ShouldCompress(props, compression)
 	blobName := GenBlobName(i.db, i.table, nower(), filepath.Base(uuid.New().String()), filepath.Base(from), compression, shouldCompress, props.Ingestion.Additional.Format.String())
 
@@ -419,18 +419,23 @@ func (i *Ingestion) localToBlob(ctx context.Context, from string, client *azblob
 func GenBlobName(databaseName string, tableName string, time time.Time, guid string, fileName string, compressionFileExtension ingestoptions.CompressionType, shouldCompress bool, dataFormat string) string {
 	extension := "gz"
 	if !shouldCompress {
-		if compressionFileExtension == ingestoptions.CTNone {
-			extension = dataFormat
-		} else {
-			extension = compressionFileExtension.String()
-		}
-
 		extension = dataFormat
+		if compressionTypeExt, ok := compressionFileExtension.ToFileExtension(); ok {
+			extension = compressionTypeExt
+		}
 	}
 
 	blobName := fmt.Sprintf("%s_%s_%s_%s_%s.%s", databaseName, tableName, time, guid, fileName, extension)
 
 	return blobName
+}
+
+func effectiveCompressionType(props *properties.All, sourcePath string) ingestoptions.CompressionType {
+	if props.Source.CompressionType != ingestoptions.CTUnknown {
+		return props.Source.CompressionType
+	}
+
+	return utils.CompressionDiscovery(sourcePath)
 }
 
 // Do not compress if user specified in DontCompress or CompressionType,

--- a/azkustoingest/internal/queued/queued_test.go
+++ b/azkustoingest/internal/queued/queued_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -84,12 +85,14 @@ func TestCompressionDiscovery(t *testing.T) {
 type fakeBlobstore struct {
 	out       *bytes.Buffer
 	shouldErr bool
+	blobName  string
 }
 
-func (f *fakeBlobstore) uploadBlobStream(_ context.Context, reader io.Reader, _ *azblob.Client, _ string, _ string, _ *azblob.UploadStreamOptions) (azblob.UploadStreamResponse, error) {
+func (f *fakeBlobstore) uploadBlobStream(_ context.Context, reader io.Reader, _ *azblob.Client, _ string, blob string, _ *azblob.UploadStreamOptions) (azblob.UploadStreamResponse, error) {
 	if f.shouldErr {
 		return azblob.UploadStreamResponse{}, fmt.Errorf("error")
 	}
+	f.blobName = blob
 	_, err := io.Copy(f.out, reader)
 	return azblob.UploadStreamResponse{}, err
 }
@@ -365,6 +368,107 @@ func TestShouldCompress(t *testing.T) {
 			assert.Equal(t, test.want, got)
 		})
 	}
+}
+
+func TestGenBlobName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                  string
+		compressionFromSource ingestoptions.CompressionType
+		shouldCompress        bool
+		dataFormat            string
+		expectedSuffix        string
+	}{
+		{
+			name:                  "should compress always yields gz",
+			compressionFromSource: ingestoptions.CTNone,
+			shouldCompress:        true,
+			dataFormat:            "csv",
+			expectedSuffix:        ".gz",
+		},
+		{
+			name:                  "no compression and no source compression uses csv",
+			compressionFromSource: ingestoptions.CTNone,
+			shouldCompress:        false,
+			dataFormat:            "csv",
+			expectedSuffix:        ".csv",
+		},
+		{
+			name:                  "no compression and no source compression uses json",
+			compressionFromSource: ingestoptions.CTNone,
+			shouldCompress:        false,
+			dataFormat:            "json",
+			expectedSuffix:        ".json",
+		},
+		{
+			name:                  "unknown source compression falls back to format",
+			compressionFromSource: ingestoptions.CTUnknown,
+			shouldCompress:        false,
+			dataFormat:            "csv",
+			expectedSuffix:        ".csv",
+		},
+		{
+			name:                  "explicit gzip source compression keeps gz suffix",
+			compressionFromSource: ingestoptions.GZIP,
+			shouldCompress:        false,
+			dataFormat:            "csv",
+			expectedSuffix:        ".gz",
+		},
+		{
+			name:                  "explicit zip source compression keeps zip suffix",
+			compressionFromSource: ingestoptions.ZIP,
+			shouldCompress:        false,
+			dataFormat:            "csv",
+			expectedSuffix:        ".zip",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			blobName := GenBlobName("db", "table", nower(), "guid", "file", tt.compressionFromSource, tt.shouldCompress, tt.dataFormat)
+			assert.True(t, strings.HasSuffix(blobName, tt.expectedSuffix), "expected %q to have suffix %q", blobName, tt.expectedSuffix)
+		})
+	}
+}
+
+func TestUploadReaderToBlobRespectsExplicitCompressionTypeForBlobName(t *testing.T) {
+	t.Parallel()
+
+	const content = "The quick brown fox jumps over the lazy dog"
+
+	var compressed bytes.Buffer
+	gzw := gzip.NewWriter(&compressed)
+	_, err := gzw.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, gzw.Close())
+
+	fbs := &fakeBlobstore{out: &bytes.Buffer{}}
+	i := &Ingestion{
+		db:           "database",
+		table:        "table",
+		uploadStream: fbs.uploadBlobStream,
+		mgr: newFakeResourceManager(
+			[]string{"https://account.blob.core.windows.net/container"},
+			[]string{"https://account.queue.core.windows.net/queue"},
+			nil,
+		),
+	}
+
+	_, _, err = i.UploadReaderToBlob(t.Context(), bytes.NewReader(compressed.Bytes()), properties.All{
+		Source: properties.SourceOptions{
+			CompressionType: ingestoptions.GZIP,
+		},
+		Ingestion: properties.Ingestion{
+			Additional: properties.Additional{Format: properties.CSV},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, compressed.Bytes(), fbs.out.Bytes(), "reader payload should not be recompressed when source is already gzip")
+	assert.True(t, strings.HasSuffix(fbs.blobName, ".gz"), "expected blob name to retain gzip extension, got %q", fbs.blobName)
 }
 
 type retryingBlobstore struct {


### PR DESCRIPTION
### Added
### Changed
### Fixed

GenBlobName in non-compression cases would incorrectly override the blob extension it had just determined in an if-statement above. Compression discovery also prefers the Source.CompressionType configuration before falling back to discovery.

This allows use cases of pre-compressing data with more efficient gzip writers along with configuring azkustoingest.DontCompress() + azkustoingest.CompressionType(ingestoptions.GZIP)

### Removed
### Security
